### PR TITLE
fix(Toolbar): ToolbarController now polls on pane instead of host

### DIFF
--- a/packages/Toolbar/ToolbarController.ts
+++ b/packages/Toolbar/ToolbarController.ts
@@ -43,7 +43,7 @@ export class ToolbarController extends Controller {
 	get intersectionController() { return this._intersectionController }
 
 	beginObserving(root: ToolbarPane) {
-		this._intersectionController = new IntersectionController(this.host, {
+		this._intersectionController = new IntersectionController(root, {
 			target: null,
 			config: { threshold: .99, root },
 			callback: entries => {
@@ -57,7 +57,7 @@ export class ToolbarController extends Controller {
 					}
 				}
 				if (changed) {
-					this.host.requestUpdate()
+					root.requestUpdate()
 				}
 			}
 		})


### PR DESCRIPTION
Polling on host can cause some disruptions on more intricate implementation, and can lead to massive performance loads.
Unfortunately this constant update polling behaviour is caused by the intersection observer and cannot be fully eliminated.
For now its symptoms are controlled by limiting the polling to the pane instead of the entire hosting component.