### PR TITLE
feat: DEV-7492: Align the language select to end with the field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27926,7 +27926,7 @@
 		},
 		"packages/LanguageField": {
 			"name": "@3mo/language-field",
-			"version": "0.1.3",
+			"version": "0.1.4",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/dialog": "x",
@@ -28185,7 +28185,7 @@
 		},
 		"packages/SelectField": {
 			"name": "@3mo/select-field",
-			"version": "0.2.5",
+			"version": "0.2.6",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/field": "x",

--- a/packages/LanguageField/LanguageField.stories.ts
+++ b/packages/LanguageField/LanguageField.stories.ts
@@ -55,6 +55,7 @@ export const OptionTemplate = story({
 				></mo-field-text>
 			`}
 			.optionTemplate=${(language: Language) => html`
+				[${language.id}]
 				${language.name.toUpperCase()}
 				<img src=${ifDefined(language.flagImageSource)} style='width: 30px'>
 			`}

--- a/packages/LanguageField/LanguageField.stories.ts
+++ b/packages/LanguageField/LanguageField.stories.ts
@@ -1,5 +1,5 @@
 import { story, meta } from '../../.storybook/story.js'
-import { html } from '@a11d/lit'
+import { html, ifDefined } from '@a11d/lit'
 import p from './package.json'
 import './index.js'
 import { Language as LanguageBase, LanguageField as LanguageFieldBase } from './index.js'
@@ -38,6 +38,25 @@ export const ModeAttach = story({
 					value=${value}
 					@change=${(e: CustomEvent<string>) => handleChange(e.detail)}
 				></mo-field-text>
+			`}
+		></story-language-field>
+	`
+})
+
+
+export const OptionTemplate = story({
+	render: () => html`
+		<story-language-field label='Label'
+			.fieldTemplate=${(value: string, handleChange: (value: string) => void, label: string, language: Language) => html`
+				<mo-field-text
+					label=${`${label} (${language.name})`}
+					value=${value}
+					@change=${(e: CustomEvent<string>) => handleChange(e.detail)}
+				></mo-field-text>
+			`}
+			.optionTemplate=${(language: Language) => html`
+				${language.name.toUpperCase()}
+				<img src=${ifDefined(language.flagImageSource)} style='width: 30px'>
 			`}
 		></story-language-field>
 	`

--- a/packages/LanguageField/LanguageField.ts
+++ b/packages/LanguageField/LanguageField.ts
@@ -162,7 +162,7 @@ export abstract class LanguageField<TValue, TLanguage extends Language> extends 
 
 	protected get flagTemplate() {
 		return !this.selectedLanguage?.flagImageSource ? nothing : html`
-			<img src=${ifDefined(this.selectedLanguage.flagImageSource)} style='width: 30px'>
+			<img src=${ifDefined(this.selectedLanguage.flagImageSource)} ${style({ width: '30px', marginLeft: this._languages.length < 2 ? '10px' : '0px' })}>
 		`
 	}
 

--- a/packages/LanguageField/LanguageField.ts
+++ b/packages/LanguageField/LanguageField.ts
@@ -130,7 +130,7 @@ export abstract class LanguageField<TValue, TLanguage extends Language> extends 
 	protected get languageSelectorTemplate() {
 		return html`
 			${this._languages.length === 0 ? nothing : html`
-				<mo-field-select slot='attachment' label='' ?dense=${this.dense} alignment='end'
+				<mo-field-select slot='attachment' label='' ?dense=${this.dense} menuAlignment='end'
 					value=${ifDefined(this.selectedLanguage?.[this.valueKey])}
 					@change=${(e: CustomEvent<TLanguage[keyof TLanguage]>) => this.handleLanguageChange(this._languages.find(l => l[this.valueKey] === e.detail) as TLanguage)}
 				>
@@ -162,7 +162,7 @@ export abstract class LanguageField<TValue, TLanguage extends Language> extends 
 
 	protected get flagTemplate() {
 		return !this.selectedLanguage?.flagImageSource ? nothing : html`
-			<img src=${ifDefined(this.selectedLanguage.flagImageSource)} ${style({ width: '30px', marginLeft: this._languages.length < 2 ? '10px' : '0px' })}>
+			<img src=${ifDefined(this.selectedLanguage.flagImageSource)} ${style({ width: '30px', marginInlineStart: this._languages.length < 2 ? '10px' : '0px' })}>
 		`
 	}
 

--- a/packages/LanguageField/LanguageField.ts
+++ b/packages/LanguageField/LanguageField.ts
@@ -7,12 +7,12 @@ import { FieldPairMode } from '@3mo/field-pair'
  * @attr mode
  * @attr valueKey
  * @attr label
+ * @attr dialogSize
  * @attr dense
  * @attr value
  * @attr selectedLanguage
  * @attr defaultLanguage
  * @attr fieldTemplate
- * @attr dialogSize
  * @attr optionTemplate
  *
  * @fires change

--- a/packages/LanguageField/LanguageField.ts
+++ b/packages/LanguageField/LanguageField.ts
@@ -120,7 +120,7 @@ export abstract class LanguageField<TValue, TLanguage extends Language> extends 
 	protected get languageSelectorTemplate() {
 		return html`
 			${!this._languages.length ? nothing : html`
-				<mo-field-select slot='attachment' label='' ?dense=${this.dense}
+				<mo-field-select slot='attachment' label='' ?dense=${this.dense} alignment='end'
 					value=${ifDefined(this.selectedLanguage?.[this.valueKey])}
 					@change=${(e: CustomEvent<TLanguage[keyof TLanguage]>) => this.handleLanguageChange(this._languages.find(l => l[this.valueKey] === e.detail) as TLanguage)}
 				>

--- a/packages/LanguageField/LanguageField.ts
+++ b/packages/LanguageField/LanguageField.ts
@@ -13,6 +13,7 @@ import { FieldPairMode } from '@3mo/field-pair'
  * @attr defaultLanguage
  * @attr fieldTemplate
  * @attr dialogSize
+ * @attr optionTemplate
  *
  * @fires change
  * @fires languageChange
@@ -34,6 +35,7 @@ export abstract class LanguageField<TValue, TLanguage extends Language> extends 
 	@property({ type: Object }) selectedLanguage?: TLanguage
 	@property({ type: Object }) defaultLanguage?: TLanguage
 	@property({ type: Object }) fieldTemplate?: (value: TValue, handleChange: (value: TValue) => void, label: string, language: TLanguage) => HTMLTemplateResult
+	@property({ type: Object }) optionTemplate?: (language: TLanguage) => HTMLTemplateResult
 
 	@state() protected _languages = new Array<TLanguage>()
 	get languages() { return this._languages }
@@ -42,6 +44,10 @@ export abstract class LanguageField<TValue, TLanguage extends Language> extends 
 
 	get getFieldTemplate() {
 		return this.fieldTemplate
+	}
+
+	get getOptionTemplate() {
+		return this.optionTemplate
 	}
 
 	protected override initialized() {
@@ -134,8 +140,10 @@ export abstract class LanguageField<TValue, TLanguage extends Language> extends 
 
 					${this._languages.map(language => html`
 						<mo-option value=${language[this.valueKey]} .data=${language}>
-							<img src=${ifDefined(language?.flagImageSource)} style='width: 30px'>
-							${language.name}
+							${this.getOptionTemplate ? this.getOptionTemplate(language) : html`
+								<img src=${ifDefined(language?.flagImageSource)} style='width: 30px'>
+								${language.name}
+							`}
 						</mo-option>
 					`)}
 				</mo-field-select>

--- a/packages/LanguageField/LanguageField.ts
+++ b/packages/LanguageField/LanguageField.ts
@@ -119,7 +119,7 @@ export abstract class LanguageField<TValue, TLanguage extends Language> extends 
 
 	protected get languageSelectorTemplate() {
 		return html`
-			${!this._languages.length ? nothing : html`
+			${this._languages.length < 2 ? nothing : html`
 				<mo-field-select slot='attachment' label='' ?dense=${this.dense} alignment='end'
 					value=${ifDefined(this.selectedLanguage?.[this.valueKey])}
 					@change=${(e: CustomEvent<TLanguage[keyof TLanguage]>) => this.handleLanguageChange(this._languages.find(l => l[this.valueKey] === e.detail) as TLanguage)}

--- a/packages/LanguageField/LanguageField.ts
+++ b/packages/LanguageField/LanguageField.ts
@@ -89,6 +89,10 @@ export abstract class LanguageField<TValue, TLanguage extends Language> extends 
 			:host([single]) mo-field-pair {
 				--mo-field-pair-attachment-width: 50px;
 			}
+
+			:host([single]) mo-field-select {
+				pointer-events: none
+			}
 		`
 	}
 
@@ -119,7 +123,7 @@ export abstract class LanguageField<TValue, TLanguage extends Language> extends 
 
 	protected get languageSelectorTemplate() {
 		return html`
-			${this._languages.length < 2 ? nothing : html`
+			${this._languages.length === 0 ? nothing : html`
 				<mo-field-select slot='attachment' label='' ?dense=${this.dense} alignment='end'
 					value=${ifDefined(this.selectedLanguage?.[this.valueKey])}
 					@change=${(e: CustomEvent<TLanguage[keyof TLanguage]>) => this.handleLanguageChange(this._languages.find(l => l[this.valueKey] === e.detail) as TLanguage)}

--- a/packages/LanguageField/package.json
+++ b/packages/LanguageField/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/language-field",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "A language field web component",
 	"repository": {
 		"type": "git",

--- a/packages/SelectField/FieldSelect.ts
+++ b/packages/SelectField/FieldSelect.ts
@@ -2,9 +2,9 @@ import { html, property, css, event, component, live, query, nothing, eventListe
 import { FieldComponent } from '@3mo/field'
 import type { ListItem } from '@3mo/list'
 import type { Menu } from '@3mo/menu'
+import { PopoverAlignment } from '@3mo/popover'
 import { Option } from './Option.js'
 import { Data, FieldSelectValueController, Index, Value } from './SelectValueController.js'
-import { PopoverAlignment } from '@3mo/popover'
 
 /**
  * @element mo-field-select

--- a/packages/SelectField/FieldSelect.ts
+++ b/packages/SelectField/FieldSelect.ts
@@ -1,4 +1,4 @@
-import { html, property, css, event, component, live, query, nothing, eventListener, state } from '@a11d/lit'
+import { html, property, css, event, component, live, query, nothing, eventListener, state, ifDefined } from '@a11d/lit'
 import { FieldComponent } from '@3mo/field'
 import type { ListItem } from '@3mo/list'
 import type { Menu } from '@3mo/menu'
@@ -33,7 +33,7 @@ export class FieldSelect<T> extends FieldComponent<Value> {
 	@property({ type: Boolean }) reflectDefault = false
 	@property({ type: Boolean }) multiple = false
 	@property({ type: Boolean }) searchable = false
-	@property() alignment = PopoverAlignment.Start
+	@property() menuAlignment?: PopoverAlignment
 	@property({
 		type: Boolean,
 		reflect: true,
@@ -184,7 +184,7 @@ export class FieldSelect<T> extends FieldComponent<Value> {
 				fixed
 				selectionMode=${this.multiple ? 'multiple' : 'single'}
 				.anchor=${this}
-				.alignment=${this.alignment}
+				alignment=${ifDefined(this.menuAlignment)}
 				?disabled=${this.disabled}
 				?open=${this.open}
 				@openChange=${(e: CustomEvent<boolean>) => this.open = e.detail}

--- a/packages/SelectField/FieldSelect.ts
+++ b/packages/SelectField/FieldSelect.ts
@@ -4,6 +4,7 @@ import type { ListItem } from '@3mo/list'
 import type { Menu } from '@3mo/menu'
 import { Option } from './Option.js'
 import { Data, FieldSelectValueController, Index, Value } from './SelectValueController.js'
+import { PopoverAlignment } from '@3mo/popover'
 
 /**
  * @element mo-field-select
@@ -31,6 +32,7 @@ export class FieldSelect<T> extends FieldComponent<Value> {
 	@property({ type: Boolean }) reflectDefault = false
 	@property({ type: Boolean }) multiple = false
 	@property({ type: Boolean }) searchable = false
+	@property() alignment = PopoverAlignment.Start
 	@property({
 		type: Boolean,
 		reflect: true,
@@ -181,6 +183,7 @@ export class FieldSelect<T> extends FieldComponent<Value> {
 				fixed
 				selectionMode=${this.multiple ? 'multiple' : 'single'}
 				.anchor=${this}
+				.alignment=${this.alignment}
 				?disabled=${this.disabled}
 				?open=${this.open}
 				@openChange=${(e: CustomEvent<boolean>) => this.open = e.detail}

--- a/packages/SelectField/FieldSelect.ts
+++ b/packages/SelectField/FieldSelect.ts
@@ -16,6 +16,7 @@ import { PopoverAlignment } from '@3mo/popover'
  * @attr value - Whether the options should be searchable.
  * @attr index - Whether the options should be searchable.
  * @attr data - Whether the options should be searchable.
+ * @attr alignment - Popover alignment
  *
  * @slot - The select options.
  *

--- a/packages/SelectField/package.json
+++ b/packages/SelectField/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/select-field",
-	"version": "0.2.5",
+	"version": "0.2.6",
 	"description": "A select field web component",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Changes:
- aligned the language selectbox to end with the field;
- hide select if there is only one language (it is made using `pointer-events` because I decided not to hide the 'attachments' slot at all and even without options `mo-field-select` still has a click animation);
- added `optionTemplate` so it would be possible to do anything with language option (e.g. capitalize language code/move flag to the right side)