### PR TITLE
feat(DataGrid): Add footer background and text customization for sums

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25076,7 +25076,7 @@
 		},
 		"packages/DataGrid": {
 			"name": "@3mo/data-grid",
-			"version": "0.4.12",
+			"version": "0.4.13",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/checkbox": "x",

--- a/packages/DataGrid/DataGrid.stories.ts
+++ b/packages/DataGrid/DataGrid.stories.ts
@@ -96,8 +96,7 @@ export const Sums = story({
 			<mo-data-grid-column-number heading='Age' dataSelector='age' sumHeading='Ages Total'></mo-data-grid-column-number>
 			<mo-data-grid-column-text heading='City' dataSelector='city'></mo-data-grid-column-text>
 			<mo-data-grid-column-currency heading='Balance' dataSelector='balance' sumHeading='Balances Total'></mo-data-grid-column-currency>
-			<mo-data-grid-footer-sum heading='Gestamt' slot='sum' align='center' ${style({ fontSize: '13px', gap: '4px' })}>1 Ware</mo-data-grid-footer-sum>
-			<mo-data-grid-footer-sum heading='Preis' slot='sum' align='end' weight='800' ${style({ fontSize: '13px', gap: '4px' })}>199,99 €</mo-data-grid-footer-sum>
+			<mo-data-grid-footer-sum slot='sum' heading='Customized Sum Maybe!' ${style({ alignItems: 'center', fontWeight: '800' })}>199,99 €</mo-data-grid-footer-sum>
 		</mo-data-grid>
 	`
 })

--- a/packages/DataGrid/DataGrid.stories.ts
+++ b/packages/DataGrid/DataGrid.stories.ts
@@ -85,12 +85,19 @@ export const ContextMenu = story({
 
 export const Sums = story({
 	render: () => html`
-		<mo-data-grid .data=${generatePeople(50).map(x => ({ ...x, balance: Math.floor(Math.random() * 1000) }))} selectionMode='multiple' style='height: 500px' selectOnClick>
+		<mo-data-grid
+			.data=${generatePeople(50).map(x => ({ ...x, balance: Math.floor(Math.random() * 1000) }))}
+			selectionMode='multiple'
+			style='height: 500px; --mo-data-grid-footer-background: var(--mo-color-transparent-gray-3)'
+			selectOnClick
+		>
 			<mo-data-grid-column-number hidden nonEditable heading='ID' dataSelector='id'></mo-data-grid-column-number>
 			<mo-data-grid-column-text heading='Name' dataSelector='name'></mo-data-grid-column-text>
 			<mo-data-grid-column-number heading='Age' dataSelector='age' sumHeading='Ages Total'></mo-data-grid-column-number>
 			<mo-data-grid-column-text heading='City' dataSelector='city'></mo-data-grid-column-text>
 			<mo-data-grid-column-currency heading='Balance' dataSelector='balance' sumHeading='Balances Total'></mo-data-grid-column-currency>
+			<mo-data-grid-footer-sum heading='Gestamt' slot='sum' align='center' ${style({ fontSize: '13px', gap: '4px' })}>1 Ware</mo-data-grid-footer-sum>
+			<mo-data-grid-footer-sum heading='Preis' slot='sum' align='end' weight='800' ${style({ fontSize: '13px', gap: '4px' })}>199,99 €</mo-data-grid-footer-sum>
 		</mo-data-grid>
 	`
 })

--- a/packages/DataGrid/DataGrid.ts
+++ b/packages/DataGrid/DataGrid.ts
@@ -570,6 +570,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 
 			mo-data-grid-footer {
 				transition: var(--mo-data-grid-fab-transition, 250ms);
+				background-color: var(--mo-data-grid-footer-background, transparent);
 			}
 
 			:host([hasSums][hasFabs]:not([fabSlotCollapsed])) mo-data-grid-footer {

--- a/packages/DataGrid/DataGrid.ts
+++ b/packages/DataGrid/DataGrid.ts
@@ -107,6 +107,7 @@ export type DataGridSorting<TData> = DataGridSortingDefinition<TData> | Array<Da
  * @slot error-no-content - A slot for displaying an error message when no data is available.
  *
  * @cssprop --mo-data-grid-min-visible-rows - The minimum number of visible rows. Default to 2.5.
+ * @cssprop --mo-data-grid-footer-background - The background of the footer.
  *
  * @fires dataChange {CustomEvent<Array<TData>>}
  * @fires selectionChange {CustomEvent<Array<TData>>}
@@ -570,7 +571,6 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 
 			mo-data-grid-footer {
 				transition: var(--mo-data-grid-fab-transition, 250ms);
-				background-color: var(--mo-data-grid-footer-background, transparent);
 			}
 
 			:host([hasSums][hasFabs]:not([fabSlotCollapsed])) mo-data-grid-footer {

--- a/packages/DataGrid/DataGridFooter.ts
+++ b/packages/DataGrid/DataGridFooter.ts
@@ -53,6 +53,7 @@ export class DataGridFooter<TData> extends Component {
 				grid-column: 1 / last-line;
 				grid-row: 3;
 				min-height: var(--mo-data-grid-footer-min-height);
+				background: var(--mo-data-grid-footer-background);
 			}
 
 			:host(:not([hideTopBorder])) {

--- a/packages/DataGrid/columns/DataGridColumn.ts
+++ b/packages/DataGrid/columns/DataGridColumn.ts
@@ -10,6 +10,7 @@ import type { ColumnDefinition } from '../ColumnDefinition.js'
  * @attr textAlign - The text alignment of the column
  * @attr title - The title of the column
  * @attr dataSelector - The data selector of the column
+ * @attr sortDataSelector - The data selector of the column
  * @attr nonSortable - Whether the column is sortable
  * @attr nonEditable - Whether the column is editable
  */

--- a/packages/DataGrid/columns/number/DataGridFooterSum.ts
+++ b/packages/DataGrid/columns/number/DataGridFooterSum.ts
@@ -4,7 +4,7 @@ import { component, property, Component, html, css, style } from '@a11d/lit'
  * @element mo-data-grid-footer-sum
  *
  * @attr heading
- * @attr textAlign
+ * @attr align
  * @attr weight
  *
  * @slot - Sum of values

--- a/packages/DataGrid/columns/number/DataGridFooterSum.ts
+++ b/packages/DataGrid/columns/number/DataGridFooterSum.ts
@@ -1,13 +1,19 @@
-import { component, property, Component, html, css } from '@a11d/lit'
+import { component, property, Component, html, css, style } from '@a11d/lit'
 
 /**
  * @element mo-data-grid-footer-sum
+ *
  * @attr heading
+ * @attr textAlign
+ * @attr weight
+ *
  * @slot - Sum of values
  */
 @component('mo-data-grid-footer-sum')
 export class DataGridFooterSum extends Component {
 	@property() heading = ''
+	@property() align: 'start' | 'end' | 'center' = 'center'
+	@property() weight = '400'
 
 	static override get styles() {
 		return css`
@@ -23,15 +29,19 @@ export class DataGridFooterSum extends Component {
 			div {
 				color: var(--mo-color-gray);
 				font-size: 0.75rem;
-				text-align: end;
 			}
 		`
 	}
 
 	protected override get template() {
 		return html`
-			<div>${this.heading}</div>
-			<mo-flex direction='horizontal' justifyContent='center' alignItems='center'>
+			<style>
+				* {
+					font-weight: ${this.weight};
+				}
+			</style>
+			<div ${style({ textAlign: this.align })}>${this.heading}</div>
+			<mo-flex direction='horizontal' justifyContent='center' alignItems=${this.align}>
 				<slot></slot>
 			</mo-flex>
 		`

--- a/packages/DataGrid/columns/number/DataGridFooterSum.ts
+++ b/packages/DataGrid/columns/number/DataGridFooterSum.ts
@@ -1,19 +1,15 @@
-import { component, property, Component, html, css, style } from '@a11d/lit'
+import { component, property, Component, html, css } from '@a11d/lit'
 
 /**
  * @element mo-data-grid-footer-sum
  *
  * @attr heading
- * @attr align
- * @attr weight
  *
  * @slot - Sum of values
  */
 @component('mo-data-grid-footer-sum')
 export class DataGridFooterSum extends Component {
 	@property() heading = ''
-	@property() align: 'start' | 'end' | 'center' = 'center'
-	@property() weight = '400'
 
 	static override get styles() {
 		return css`
@@ -24,6 +20,7 @@ export class DataGridFooterSum extends Component {
 				max-height: 100%;
 				line-height: 1em;
 				user-select: all;
+				align-items: flex-end;
 			}
 
 			div {
@@ -35,13 +32,8 @@ export class DataGridFooterSum extends Component {
 
 	protected override get template() {
 		return html`
-			<style>
-				* {
-					font-weight: ${this.weight};
-				}
-			</style>
-			<div ${style({ textAlign: this.align })}>${this.heading}</div>
-			<mo-flex direction='horizontal' justifyContent='center' alignItems=${this.align}>
+			<div>${this.heading}</div>
+			<mo-flex direction='horizontal' justifyContent='center'>
 				<slot></slot>
 			</mo-flex>
 		`

--- a/packages/DataGrid/package.json
+++ b/packages/DataGrid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/data-grid",
-	"version": "0.4.12",
+	"version": "0.4.13",
 	"description": "A data grid web component",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Changes:
- added background via `--mo-data-grid-footer-background` CSS variable;
- added `align` and `weight` props for footer sum.
