### PR TITLE
feat(TextFields): Support reveal password functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26114,6 +26114,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/field": "x",
+				"@3mo/icon": "x",
+				"@3mo/icon-button": "x",
 				"@3mo/localization": "x",
 				"@a11d/lit": "x",
 				"tslib": "x"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25146,7 +25146,7 @@
 		},
 		"packages/DateTimeFields": {
 			"name": "@3mo/date-time-fields",
-			"version": "0.4.1",
+			"version": "0.4.2",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/date-time": "x",
@@ -25181,7 +25181,7 @@
 		},
 		"packages/DesignLibrary": {
 			"name": "@3mo/del",
-			"version": "0.1.19",
+			"version": "0.1.20",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/alert": "x",
@@ -26110,7 +26110,7 @@
 		},
 		"packages/TextFields": {
 			"name": "@3mo/text-fields",
-			"version": "0.0.7",
+			"version": "0.0.8",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/field": "x",

--- a/packages/DateTimeFields/FieldTime.ts
+++ b/packages/DateTimeFields/FieldTime.ts
@@ -5,7 +5,9 @@ import { FieldText } from '@3mo/text-fields'
 
 @component('mo-field-time')
 export class FieldTime extends FieldText {
-	override readonly inputType = 'time'
+	override get inputType() {
+		return 'time'
+	}
 
 	protected override get startSlotTemplate() {
 		return html`

--- a/packages/DateTimeFields/package.json
+++ b/packages/DateTimeFields/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/date-time-fields",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "A set of date-time related fields.",
 	"repository": {
 		"type": "git",

--- a/packages/DesignLibrary/BusinessSuiteDialogAuthenticator.ts
+++ b/packages/DesignLibrary/BusinessSuiteDialogAuthenticator.ts
@@ -13,6 +13,7 @@ Localizer.register('de', {
 	'Username': 'Benutzer',
 	'Password': 'Passwort',
 	'Remember Password': 'Passwort merken',
+	'Show Password': 'Passwort anzeigen',
 	'Reset Password': 'Passwort zurücksetzen',
 	'Welcome': 'Willkommen',
 	'Login': 'Anmelden'
@@ -23,12 +24,19 @@ export type User = {
 	email?: string
 }
 
+const isMobileOrTablet = () => {
+	return /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(navigator.userAgent)
+  	|| /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(navigator.userAgent.slice(0, 4))
+}
+
 export abstract class BusinessSuiteDialogAuthenticator extends DialogAuthenticatorBase<User> {
 	static readonly authenticatedUserStorage = new LocalStorage<object | undefined>('DialogAuthenticator.User', undefined)
 
 	protected abstract requestPasswordReset(): Promise<void>
 
 	@state() primaryButtonText = t('Login')
+
+	@state() previewPassword = isMobileOrTablet()
 
 	protected override get template() {
 		return html`
@@ -76,8 +84,14 @@ export abstract class BusinessSuiteDialogAuthenticator extends DialogAuthenticat
 				<mo-field-password
 					label=${t('Password')}
 					.value=${this.password}
+					?preview=${this.previewPassword}
 					@input=${(e: CustomEvent<string>) => this.password = e.detail}
 				></mo-field-password>
+
+				<mo-checkbox label=${t('Show Password')}
+					?selected=${this.previewPassword}
+					@change=${(e: CustomEvent<boolean>) => this.previewPassword = e.detail}
+				></mo-checkbox>
 
 				<mo-flex direction='horizontal' justifyContent='space-between' alignItems='center' wrap='wrap-reverse'>
 					<mo-checkbox

--- a/packages/DesignLibrary/BusinessSuiteDialogAuthenticator.ts
+++ b/packages/DesignLibrary/BusinessSuiteDialogAuthenticator.ts
@@ -1,4 +1,4 @@
-import { html, state, style } from '@a11d/lit'
+import { bind, html, state, style } from '@a11d/lit'
 import { DialogAuthenticator as DialogAuthenticatorBase } from '@a11d/lit-application-authentication'
 import { Localizer } from '@3mo/localization'
 import { LocalStorage } from '@a11d/local-storage'
@@ -24,11 +24,6 @@ export type User = {
 	email?: string
 }
 
-const isMobileOrTablet = () => {
-	return /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(navigator.userAgent)
-  	|| /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(navigator.userAgent.slice(0, 4))
-}
-
 export abstract class BusinessSuiteDialogAuthenticator extends DialogAuthenticatorBase<User> {
 	static readonly authenticatedUserStorage = new LocalStorage<object | undefined>('DialogAuthenticator.User', undefined)
 
@@ -36,7 +31,7 @@ export abstract class BusinessSuiteDialogAuthenticator extends DialogAuthenticat
 
 	@state() primaryButtonText = t('Login')
 
-	@state() previewPassword = isMobileOrTablet()
+	@state() revealPassword = false
 
 	protected override get template() {
 		return html`
@@ -77,28 +72,18 @@ export abstract class BusinessSuiteDialogAuthenticator extends DialogAuthenticat
 			<mo-flex gap='var(--mo-thickness-l)' ${style({ flex: '1', width: '100%', paddingBottom: '25px' })}>
 				<mo-field-text data-focus
 					label=${t('Username')}
-					.value=${this.username}
-					@input=${(e: CustomEvent<string>) => this.username = e.detail}
+					${bind(this, 'username', { event: 'input' })}
 				></mo-field-text>
 
-				<mo-field-password
-					label=${t('Password')}
-					.value=${this.password}
-					?preview=${this.previewPassword}
-					@input=${(e: CustomEvent<string>) => this.password = e.detail}
+				<mo-field-password label=${t('Password')}
+					?reveal=${this.revealPassword}
+					${bind(this, 'password', { event: 'input' })}
 				></mo-field-password>
 
-				<mo-checkbox label=${t('Show Password')}
-					?selected=${this.previewPassword}
-					@change=${(e: CustomEvent<boolean>) => this.previewPassword = e.detail}
-				></mo-checkbox>
+				<mo-checkbox label=${t('Show Password')} ${bind(this, 'revealPassword')}></mo-checkbox>
 
 				<mo-flex direction='horizontal' justifyContent='space-between' alignItems='center' wrap='wrap-reverse'>
-					<mo-checkbox
-						label=${t('Remember Password')}
-						?selected=${this.shallRememberPassword}
-						@change=${(e: CustomEvent<boolean>) => this.shallRememberPassword = e.detail}
-					></mo-checkbox>
+					<mo-checkbox label=${t('Remember Password')} ${bind(this, 'shallRememberPassword')}></mo-checkbox>
 
 					<mo-anchor ${style({ fontSize: 'small' })} @click=${() => this.resetPassword()}>${t('Reset Password')}</mo-anchor>
 				</mo-flex>

--- a/packages/DesignLibrary/package.json
+++ b/packages/DesignLibrary/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/del",
-	"version": "0.1.19",
+	"version": "0.1.20",
 	"description": "3MO Design Library to build business-suite web applications",
 	"repository": {
 		"type": "git",

--- a/packages/TextFields/FieldPassword.stories.ts
+++ b/packages/TextFields/FieldPassword.stories.ts
@@ -10,6 +10,7 @@ export default meta({
 		label: 'Label',
 		required: false,
 		dense: false,
+		preview: false,
 		disabled: false,
 		readonly: false,
 		value: 'Password',
@@ -24,7 +25,7 @@ export default meta({
 })
 
 export const Password = story({
-	render: ({ label, required, disabled, dense, readonly, value }) => html`
-		<mo-field-password label=${label} ?required=${required} ?disabled=${disabled} ?readonly=${readonly} ?dense=${dense} value=${value}></mo-field-password>
+	render: ({ label, required, disabled, dense, readonly, value, preview }) => html`
+		<mo-field-password label=${label} ?required=${required} ?disabled=${disabled} ?preview=${preview} ?readonly=${readonly} ?dense=${dense} value=${value}></mo-field-password>
 	`
 })

--- a/packages/TextFields/FieldPassword.stories.ts
+++ b/packages/TextFields/FieldPassword.stories.ts
@@ -10,7 +10,7 @@ export default meta({
 		label: 'Label',
 		required: false,
 		dense: false,
-		preview: false,
+		reveal: false,
 		disabled: false,
 		readonly: false,
 		value: 'Password',
@@ -25,7 +25,7 @@ export default meta({
 })
 
 export const Password = story({
-	render: ({ label, required, disabled, dense, readonly, value, preview }) => html`
-		<mo-field-password label=${label} ?required=${required} ?disabled=${disabled} ?preview=${preview} ?readonly=${readonly} ?dense=${dense} value=${value}></mo-field-password>
+	render: ({ label, required, disabled, dense, readonly, value, reveal }) => html`
+		<mo-field-password label=${label} ?required=${required} ?disabled=${disabled} ?reveal=${reveal} ?readonly=${readonly} ?dense=${dense} value=${value}></mo-field-password>
 	`
 })

--- a/packages/TextFields/FieldPassword.ts
+++ b/packages/TextFields/FieldPassword.ts
@@ -4,19 +4,16 @@ import { FieldText, FieldTextAutoComplete } from './FieldText.js'
 /**
  * @element mo-field-password
  *
+ * @attr reveal
  * @attr autoComplete
  */
 @component('mo-field-password')
 export class FieldPassword extends FieldText {
-	@property({
-		type: Boolean,
-		updated(this: FieldPassword) {
-			this.type = this.preview ? 'text' : 'password'
-			this.requestUpdate()
-		},
-	}) preview = false
+	@property({ type: Boolean }) reveal = false
 
-	protected override type = this.preview ? 'text' : 'password'
+	protected override get type() {
+		return this.reveal ? 'text' : 'password'
+	}
 
 	@property() override autoComplete: FieldTextAutoComplete = 'current-password'
 

--- a/packages/TextFields/FieldPassword.ts
+++ b/packages/TextFields/FieldPassword.ts
@@ -8,7 +8,15 @@ import { FieldText, FieldTextAutoComplete } from './FieldText.js'
  */
 @component('mo-field-password')
 export class FieldPassword extends FieldText {
-	protected override readonly type = 'password'
+	@property({
+		type: Boolean,
+		updated(this: FieldPassword) {
+			this.type = this.preview ? 'text' : 'password'
+			this.requestUpdate()
+		},
+	}) preview = false
+
+	protected override type = this.preview ? 'text' : 'password'
 
 	@property() override autoComplete: FieldTextAutoComplete = 'current-password'
 

--- a/packages/TextFields/FieldSearch.ts
+++ b/packages/TextFields/FieldSearch.ts
@@ -6,7 +6,9 @@ import { FieldText } from './FieldText.js'
  */
 @component('mo-field-search')
 export class FieldSearch extends FieldText {
-	override readonly inputType = 'search'
+	override get inputType() {
+		return 'search'
+	}
 
 	@property({ event: 'input' }) override value?: string
 

--- a/packages/TextFields/FieldText.ts
+++ b/packages/TextFields/FieldText.ts
@@ -69,14 +69,19 @@ export type FieldTextAutoComplete =
  */
 @component('mo-field-text')
 export class FieldText extends InputFieldComponent<string> {
-	protected readonly type: string = 'text'
-	protected readonly inputType: string = 'text'
-
 	@property() value?: string
 	@property({ type: Number }) minLength?: number
 	@property({ type: Number }) maxLength?: number
 	@property() pattern?: string
 	@property() autoComplete?: FieldTextAutoComplete
+
+	protected get type(): string {
+		return 'text'
+	}
+
+	protected get inputType(): string {
+		return 'text'
+	}
 
 	protected valueToInputValue(value?: string) {
 		return value ?? ''

--- a/packages/TextFields/package.json
+++ b/packages/TextFields/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/text-fields",
-	"version": "0.0.7",
+	"version": "0.0.8",
 	"description": "A set of text field component web components.",
 	"repository": {
 		"type": "git",

--- a/packages/TextFields/package.json
+++ b/packages/TextFields/package.json
@@ -31,6 +31,8 @@
 	"dependencies": {
 		"@a11d/lit": "x",
 		"tslib": "x",
+		"@3mo/icon": "x",
+		"@3mo/icon-button": "x",
 		"@3mo/field": "x",
 		"@3mo/localization": "x"
 	},


### PR DESCRIPTION
Changes:
- `preview` attribute at `mo-field-password`
- `previewPassword` state and `Password anzeigen` checkbox  at authenticator dialog 