### PR TITLE
fix(DataGridSidePanel): Fix side panel height in Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29333,7 +29333,7 @@
 		},
 		"packages/Section": {
 			"name": "@3mo/section",
-			"version": "0.1.9",
+			"version": "0.1.10",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/heading": "x",

--- a/packages/DataGrid/DataGridSidePanel.ts
+++ b/packages/DataGrid/DataGridSidePanel.ts
@@ -78,10 +78,6 @@ export class DataGridSidePanel<TData> extends Component {
 				margin-inline-start: 8px;
 				font-size: small;
 			}
-
-			mo-section::part(root) {
-				height: unset !important;
-			}
 		`
 	}
 

--- a/packages/DataGrid/DataGridSidePanel.ts
+++ b/packages/DataGrid/DataGridSidePanel.ts
@@ -78,6 +78,10 @@ export class DataGridSidePanel<TData> extends Component {
 				margin-inline-start: 8px;
 				font-size: small;
 			}
+
+			mo-section::part(root) {
+				height: unset;
+			}
 		`
 	}
 

--- a/packages/DataGrid/DataGridSidePanel.ts
+++ b/packages/DataGrid/DataGridSidePanel.ts
@@ -80,7 +80,7 @@ export class DataGridSidePanel<TData> extends Component {
 			}
 
 			mo-section::part(root) {
-				height: unset;
+				height: unset !important;
 			}
 		`
 	}

--- a/packages/Section/Section.ts
+++ b/packages/Section/Section.ts
@@ -32,6 +32,10 @@ export class Section extends Component {
 				height: 100%;
 			}
 
+			mo-grid {
+				height: max-content;
+			}
+
 			slot[name=action], slot[name=heading], slot[name=heading]::slotted(*) {
 				font-weight: 500;
 			}
@@ -82,7 +86,7 @@ export class Section extends Component {
 
 	protected get contentTemplate() {
 		return !this.slotController.hasAssignedContent('') ? html.nothing : html`
-			<mo-grid part='root' ${style({ height: '100%' })}>
+			<mo-grid>
 				<slot></slot>
 			</mo-grid>
 		`

--- a/packages/Section/Section.ts
+++ b/packages/Section/Section.ts
@@ -82,7 +82,7 @@ export class Section extends Component {
 
 	protected get contentTemplate() {
 		return !this.slotController.hasAssignedContent('') ? html.nothing : html`
-			<mo-grid ${style({ height: '100%' })}>
+			<mo-grid part='root' ${style({ height: '100%' })}>
 				<slot></slot>
 			</mo-grid>
 		`

--- a/packages/Section/Section.ts
+++ b/packages/Section/Section.ts
@@ -1,6 +1,7 @@
 import { Component, component, css, html, property, style } from '@a11d/lit'
 import { SlotController } from '@3mo/slot-controller'
 import '@3mo/heading'
+import '@3mo/grid'
 
 /**
  * @element mo-section

--- a/packages/Section/package.json
+++ b/packages/Section/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/section",
-	"version": "0.1.9",
+	"version": "0.1.10",
 	"description": "A section web-component based on Material Design.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
A 100% height doesn't work for `grid` in Safari, see https://stackoverflow.com/questions/44770074/css-grid-row-height-safari-bug (it's not a bug, it is a different interpretation of the spec). Should we change it globally? I don't think so as we haven't seen this bug anywhere except the side panel (another solution: add a global style for Safari).
