### PR TITLE
fix(Splitter): Add fallback for TouchEvent

### DIFF
--- a/packages/Splitter/Splitter.ts
+++ b/packages/Splitter/Splitter.ts
@@ -5,6 +5,10 @@ import { SplitterItem, SplitterResizerHost } from './index.js'
 import type * as CSS from 'csstype'
 import '@3mo/theme'
 
+if (!window.TouchEvent) {
+	window.TouchEvent = 'GestureEvent' in window ? (window as any).GestureEvent : class TouchEvent {}
+}
+
 /**
  * @element mo-splitter
  *


### PR DESCRIPTION
Safari doesn't have a `TouchEvent`, instead it uses `GestureEvent`. However, it works even with the anonymous class so I just added a fallback just in case.

|![](https://github.com/3mo-esolutions/web-components/assets/142882738/3cb52146-fe13-457e-91f4-fda49b1ca882)|![](https://github.com/3mo-esolutions/web-components/assets/142882738/6f27cca1-4f67-4098-9657-f6ba97a97061)|
|:-:|:-:|