### PR TITLE
fix(Card): Add max-width for card's heading

### DIFF
--- a/packages/Card/Card.ts
+++ b/packages/Card/Card.ts
@@ -128,7 +128,7 @@ export class Card extends Component {
 
 	protected override get template() {
 		return html`
-			<mo-flex part='root' ${style({ width: '100%', height: '100%' })}>
+			<mo-flex ${style({ width: '100%', height: '100%' })}>
 				${this.mediaTemplate}
 				${this.headerTemplate}
 				${this.bodyTemplate}

--- a/packages/Card/Card.ts
+++ b/packages/Card/Card.ts
@@ -73,6 +73,7 @@ export class Card extends Component {
 				align-items: center;
 				gap: 6px;
 				padding: var(--mo-card-header-padding, 16px);
+				box-sizing: border-box;
 			}
 
 			slot[name=heading] {
@@ -127,7 +128,7 @@ export class Card extends Component {
 
 	protected override get template() {
 		return html`
-			<mo-flex ${style({ width: '100%', height: '100%' })}>
+			<mo-flex part='root' ${style({ width: '100%', height: '100%' })}>
 				${this.mediaTemplate}
 				${this.headerTemplate}
 				${this.bodyTemplate}
@@ -156,7 +157,7 @@ export class Card extends Component {
 		return !isServer && !hasHeader ? html.nothing : html`
 			<slot part='header' name='header'>
 				${this.defaultHeaderAvatarTemplate}
-				<mo-flex justifyContent='space-around' ${style({ flex: '1' })}>
+				<mo-flex justifyContent='space-around' ${style({ flex: '1', maxWidth: '100%' })}>
 					${this.defaultHeaderHeadingTemplate}
 					${this.defaultHeaderSubHeadingTemplate}
 				</mo-flex>


### PR DESCRIPTION
https://3mo-ebusiness.atlassian.net/browse/DEV-6818

I tried a lot of different solutions but I just can't take these elements outside of shadow DOM (even using `part`/`exportparts` etc), but I don't think these styles would somehow break our styling. 