### PR TITLE
feat(DataGrid): Use native CSS subgrid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19125,7 +19125,7 @@
 		},
 		"packages/DataGrid": {
 			"name": "@3mo/data-grid",
-			"version": "0.6.0",
+			"version": "0.6.1",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/checkbox": "x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19125,7 +19125,7 @@
 		},
 		"packages/DataGrid": {
 			"name": "@3mo/data-grid",
-			"version": "0.5.17",
+			"version": "0.6.0",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/checkbox": "x",
@@ -19455,7 +19455,7 @@
 		},
 		"packages/FetchableDataGrid": {
 			"name": "@3mo/fetchable-data-grid",
-			"version": "0.0.7",
+			"version": "0.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/circular-progress": "x",

--- a/packages/DataGrid/DataGrid.stories.ts
+++ b/packages/DataGrid/DataGrid.stories.ts
@@ -14,7 +14,7 @@ type Person = { id: number, name: string, age: number, city: string }
 
 const generatePeople = (count: number) => {
 	const cities = ['Berlin', 'Hamburg', 'München', 'Köln', 'Frankfurt']
-	const names = ['Max', 'Moritz', 'Mia', 'Maja', 'Mika']
+	const names = ['Max', 'Moritz long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long', 'Mia', 'Maja', 'Mika long long long long long long long long long long long long long long long long long long long long long long long long long']
 	return new Array(count).fill(0).map((_, i) => ({
 		id: i + 1,
 		name: names[Math.floor(Math.random() * names.length)],
@@ -24,7 +24,8 @@ const generatePeople = (count: number) => {
 }
 
 const fivePeople = generatePeople(5)
-const thousandPeople = generatePeople(1000)
+const twentyPeople = generatePeople(20)
+const hundredPeople = generatePeople(100)
 
 const fivePeopleWithChildren = fivePeople.map(p => ({
 	...p,
@@ -33,14 +34,14 @@ const fivePeopleWithChildren = fivePeople.map(p => ({
 
 const columnsTemplate = html`
 	<mo-data-grid-column-number hidden nonEditable heading='ID' dataSelector='id'></mo-data-grid-column-number>
-	<mo-data-grid-column-text heading='Name' dataSelector='name'></mo-data-grid-column-text>
+	<mo-data-grid-column-text heading='Name' width='200px' dataSelector='name'></mo-data-grid-column-text>
 	<mo-data-grid-column-number .nonEditable=${(person: Person) => person.age > 30} heading='Age' dataSelector='age'></mo-data-grid-column-number>
 	<mo-data-grid-column-text heading='City' dataSelector='city'></mo-data-grid-column-text>
 `
 
 export const DataGrid: StoryObj = {
 	render: () => html`
-		<mo-data-grid .data=${fivePeople} style='height: 500px'>
+		<mo-data-grid .data=${twentyPeople} style='height: 500px; flex: 1'>
 			${columnsTemplate}
 		</mo-data-grid>
 	`
@@ -110,7 +111,7 @@ export const Sums: StoryObj = {
 
 export const Sorting: StoryObj = {
 	render: () => html`
-		<mo-data-grid .data=${thousandPeople} pagination='auto' selectionMode='multiple' style='height: 500px' selectOnClick .sorting=${[{ selector: 'name', strategy: DataGridSortingStrategy.Ascending }, { selector: 'age', strategy: DataGridSortingStrategy.Descending }]}>
+		<mo-data-grid .data=${hundredPeople} pagination='auto' selectionMode='multiple' style='height: 500px' selectOnClick .sorting=${[{ selector: 'name', strategy: DataGridSortingStrategy.Ascending }, { selector: 'age', strategy: DataGridSortingStrategy.Descending }]}>
 			<mo-data-grid-column-number hidden nonEditable heading='ID' dataSelector='id'></mo-data-grid-column-number>
 			<mo-data-grid-column-text heading='Name' dataSelector='name'></mo-data-grid-column-text>
 			<mo-data-grid-column-number heading='Age' dataSelector='age' sumHeading='Ages Total'></mo-data-grid-column-number>
@@ -155,6 +156,7 @@ export const WithAutoSubDataGrid: StoryObj = {
 			?detailsOnClick=${detailsOnClick}
 			.data=${fivePeopleWithChildren}
 			subDataGridDataSelector='children'
+			.getRowContextMenuTemplate=${(data: Array<Person>) => html`selected length: ${data.length}`}
 		>
 			${columnsTemplate}
 		</mo-data-grid>
@@ -192,7 +194,7 @@ export const Editability: StoryObj = {
 
 export const WithFiltersWithoutToolbar: StoryObj = {
 	render: () => html`
-		<mo-data-grid .data=${thousandPeople} style='height: 500px'>
+		<mo-data-grid .data=${hundredPeople} style='height: 500px'>
 			${columnsTemplate}
 			<mo-checkbox slot='filter' label='Something'></mo-checkbox>
 		</mo-data-grid>
@@ -201,9 +203,15 @@ export const WithFiltersWithoutToolbar: StoryObj = {
 
 export const Virtualization: StoryObj = {
 	render: () => html`
-		<mo-data-grid .data=${thousandPeople} style='height: 500px'>
-			${columnsTemplate}
-		</mo-data-grid>
+		<mo-flex gap='10px'>
+			<mo-alert type='warning'>
+				Virtualization is disabled as of version 0.6.x due to incompatibilities with CSS Sub-grids.
+				It will be re-enabled or re-worked into a different solution in a future version.
+			</mo-alert>
+			<mo-data-grid .data=${hundredPeople} style='height: 500px'>
+				${columnsTemplate}
+			</mo-data-grid>
+		</mo-flex>
 	`
 }
 
@@ -212,7 +220,7 @@ export const MinVisibleRows: StoryObj = {
 		minVisibleRows: 10
 	},
 	render: ({ minVisibleRows }) => html`
-		<mo-data-grid .data=${thousandPeople} ${style({ '--mo-data-grid-min-visible-rows': String(minVisibleRows) })}>
+		<mo-data-grid .data=${hundredPeople} ${style({ '--mo-data-grid-min-visible-rows': String(minVisibleRows) })}>
 			${columnsTemplate}
 		</mo-data-grid>
 	`
@@ -224,7 +232,7 @@ export const Fab: StoryObj = {
 		withFooter: false,
 	},
 	render: ({ label, withFooter }) => html`
-		<mo-data-grid .data=${thousandPeople} style='height: 500px' pagination=${ifDefined(withFooter ? 'auto' : undefined)}>
+		<mo-data-grid .data=${hundredPeople} style='height: 500px' pagination=${ifDefined(withFooter ? 'auto' : undefined)}>
 			${columnsTemplate}
 			<mo-fab slot='fab' icon='add'>${label}</mo-fab>
 		</mo-data-grid>

--- a/packages/DataGrid/DataGrid.stories.ts
+++ b/packages/DataGrid/DataGrid.stories.ts
@@ -238,3 +238,11 @@ export const Exportable: StoryObj = {
 		</mo-data-grid>
 	`
 }
+
+export const NoContent: StoryObj = {
+	render: () => html`
+		<mo-data-grid style='height: 500px'>
+			${columnsTemplate}
+		</mo-data-grid>
+	`
+}

--- a/packages/DataGrid/DataGrid.stories.ts
+++ b/packages/DataGrid/DataGrid.stories.ts
@@ -41,7 +41,7 @@ const columnsTemplate = html`
 
 export const DataGrid: StoryObj = {
 	render: () => html`
-		<mo-data-grid .data=${twentyPeople} style='height: 500px; flex: 1'>
+		<mo-data-grid .data=${twentyPeople} style='height: 500px'>
 			${columnsTemplate}
 		</mo-data-grid>
 	`
@@ -156,7 +156,6 @@ export const WithAutoSubDataGrid: StoryObj = {
 			?detailsOnClick=${detailsOnClick}
 			.data=${fivePeopleWithChildren}
 			subDataGridDataSelector='children'
-			.getRowContextMenuTemplate=${(data: Array<Person>) => html`selected length: ${data.length}`}
 		>
 			${columnsTemplate}
 		</mo-data-grid>

--- a/packages/DataGrid/DataGrid.ts
+++ b/packages/DataGrid/DataGrid.ts
@@ -570,7 +570,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 
 			#fab {
 				position: absolute;
-				top: -72px;
+				bottom: 8px;
 				inset-inline-end: 16px;
 				transition: var(--mo-data-grid-fab-transition, 250ms);
 			}

--- a/packages/DataGrid/DataGrid.ts
+++ b/packages/DataGrid/DataGrid.ts
@@ -496,7 +496,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 				--mo-data-grid-row-tree-line-width: 8px;
 				--mo-details-data-grid-start-margin: 26px;
 
-				--mo-data-grid-sticky-part-color: var(--mo-color-surface);
+				--mo-data-grid-sticky-part-color: var(--mo-color-surface-container-high);
 
 				--mo-data-grid-selection-background: color-mix(in srgb, var(--mo-color-accent), transparent 50%);
 				display: flex;
@@ -575,6 +575,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 				bottom: 8px;
 				inset-inline-end: 16px;
 				transition: var(--mo-data-grid-fab-transition, 250ms);
+				z-index: 3;
 			}
 
 			:host([hasFooter]) #fab {
@@ -616,6 +617,16 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 				height: 100%;
 				z-index: 1;
 				background-color: var(--mo-color-surface);
+			}
+
+			mo-grid#content:has(.span-through) {
+				min-height: 100%;
+				grid-template-rows: auto 1fr;
+			}
+
+			.span-through {
+				display: block;
+				grid-column: -1 / 1;
 			}
 		`
 	}
@@ -698,7 +709,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 
 	protected get noContentTemplate() {
 		return html`
-			<slot name='error-no-content' ${style({ display: 'block', gridColumn: '-1 / 1' })}>
+			<slot name='error-no-content' class='span-through'>
 				<mo-empty-state icon='youtube_searched_for'>${t('No results')}</mo-empty-state>
 			</slot>
 		`
@@ -731,7 +742,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 	}
 
 	private get shallVirtualize() {
-		return !this.preventVerticalContentScroll && this.renderData.length > this.virtualizationThreshold
+		return false && !this.preventVerticalContentScroll && this.renderData.length > this.virtualizationThreshold
 	}
 
 	private get rowsTemplate() {
@@ -740,7 +751,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 			? this.renderData.map(getRowTemplate)
 			: html`<mo-virtualized-scroller .items=${this.renderData} .getItemTemplate=${getRowTemplate as any} exportparts='row'></mo-virtualized-scroller>`
 		return html`
-				${content}
+			${content}
 		`
 	}
 

--- a/packages/DataGrid/DataGrid.ts
+++ b/packages/DataGrid/DataGrid.ts
@@ -214,7 +214,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 		return [...root?.querySelectorAll('[mo-data-grid-row]') ?? []] as Array<DataGridRow<TData, TDetailsElement>>
 	}
 
-	@query('mo-data-grid-header') readonly header?: DataGridHeader<TData>
+	@query('mo-data-grid-header') private readonly header?: DataGridHeader<TData>
 	@query('#content') private readonly content?: HTMLElement
 	@query('mo-data-grid-footer') private readonly footer?: DataGridFooter<TData>
 	@query('mo-data-grid-side-panel') private readonly sidePanel?: DataGridSidePanel<TData>

--- a/packages/DataGrid/DataGrid.ts
+++ b/packages/DataGrid/DataGrid.ts
@@ -719,7 +719,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 		this.provideCssColumnsProperties()
 		this.toggleAttribute('hasDetails', this.hasDetails)
 		return html`
-			<mo-grid rows='* auto' ${style({ position: 'relative' })}>
+			<mo-grid rows='* auto' ${style({ position: 'relative', height: '100%' })}>
 				<mo-scroller
 					${style({ minHeight: 'var(--mo-data-grid-content-min-height, calc(var(--mo-data-grid-min-visible-rows, 2.5) * var(--mo-data-grid-row-height) + var(--mo-data-grid-header-height)))' })}
 					${observeResize(() => this.requestUpdate())}

--- a/packages/DataGrid/DataGrid.ts
+++ b/packages/DataGrid/DataGrid.ts
@@ -483,7 +483,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 			:host {
 				--mo-data-grid-column-details-width: 20px;
 				--mo-data-grid-column-selection-width: 40px;
-				--mo-data-grid-column-more-width: 20px;
+				--mo-data-grid-column-more-width: minmax(28px, 1fr);
 
 				--mo-data-grid-header-height: 32px;
 				--mo-data-grid-footer-min-height: 40px;
@@ -495,6 +495,8 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 
 				--mo-data-grid-row-tree-line-width: 8px;
 				--mo-details-data-grid-start-margin: 26px;
+
+				--mo-data-grid-sticky-part-color: var(--mo-color-surface);
 
 				--mo-data-grid-selection-background: color-mix(in srgb, var(--mo-color-accent), transparent 50%);
 				display: flex;
@@ -696,7 +698,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 
 	protected get noContentTemplate() {
 		return html`
-			<slot name='error-no-content'>
+			<slot name='error-no-content' ${style({ display: 'block', gridColumn: '-1 / 1' })}>
 				<mo-empty-state icon='youtube_searched_for'>${t('No results')}</mo-empty-state>
 			</slot>
 		`
@@ -706,17 +708,19 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 		this.provideCssColumnsProperties()
 		this.toggleAttribute('hasDetails', this.hasDetails)
 		return html`
-			<mo-flex ${style({ flex: '1', position: 'relative' })}>
-				<mo-grid ${style({ flex: '1' })} rows='* auto'>
-					<mo-scroller ${style({ minHeight: 'var(--mo-data-grid-content-min-height, calc(var(--mo-data-grid-min-visible-rows, 2.5) * var(--mo-data-grid-row-height) + var(--mo-data-grid-header-height)))' })}>
-						<mo-grid ${style({ height: '100%' })} rows='auto *'>
-							${this.headerTemplate}
-							${this.contentTemplate}
-						</mo-grid>
-					</mo-scroller>
-					${this.footerTemplate}
-				</mo-grid>
-			</mo-flex>
+			<mo-grid rows='* auto' ${style({ position: 'relative' })}>
+				<mo-scroller
+					${style({ minHeight: 'var(--mo-data-grid-content-min-height, calc(var(--mo-data-grid-min-visible-rows, 2.5) * var(--mo-data-grid-row-height) + var(--mo-data-grid-header-height)))' })}
+					${observeResize(() => this.requestUpdate())}
+					@scroll=${this.handleScroll}
+				>
+					<mo-grid id='content' autoRows='min-content' columns='var(--mo-data-grid-columns)' columnGap='var(--mo-data-grid-columns-gap)'>
+						${this.headerTemplate}
+						${this.contentTemplate}
+					</mo-grid>
+				</mo-scroller>
+				${this.footerTemplate}
+			</mo-grid>
 		`
 	}
 
@@ -736,13 +740,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 			? this.renderData.map(getRowTemplate)
 			: html`<mo-virtualized-scroller .items=${this.renderData} .getItemTemplate=${getRowTemplate as any} exportparts='row'></mo-virtualized-scroller>`
 		return html`
-			<mo-scroller id='rowsContainer'
-				${style({ gridRow: '2', gridColumn: '1 / last-line', overflowX: 'hidden' })}
-				${observeResize(() => this.requestUpdate())}
-				@scroll=${this.handleScroll}
-			>
 				${content}
-			</mo-scroller>
 		`
 	}
 

--- a/packages/DataGrid/DataGrid.ts
+++ b/packages/DataGrid/DataGrid.ts
@@ -215,7 +215,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 	}
 
 	@query('mo-data-grid-header') readonly header?: DataGridHeader<TData>
-	@query('#rowsContainer') private readonly rowsContainer?: HTMLElement
+	@query('#content') private readonly content?: HTMLElement
 	@query('mo-data-grid-footer') private readonly footer?: DataGridFooter<TData>
 	@query('mo-data-grid-side-panel') private readonly sidePanel?: DataGridSidePanel<TData>
 	@query('slot[name=column]') private readonly columnsSlot?: HTMLSlotElement
@@ -421,7 +421,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 		}
 
 		if (this.pagination === 'auto') {
-			const rowsHeight = this.rowsContainer?.clientHeight
+			const rowsHeight = this.content?.clientHeight
 			const rowHeight = this.rowHeight
 			const pageSize = Math.floor((rowsHeight || 0) / rowHeight) || 1
 			return dynamicPageSize(pageSize)

--- a/packages/DataGrid/DataGridCell.ts
+++ b/packages/DataGrid/DataGridCell.ts
@@ -123,7 +123,7 @@ export class DataGridCell<TValue extends KeyPathValueOf<TData>, TData = any, TDe
 		return css`
 			:host {
 				position: relative;
-				padding-inline: var(--mo-data-grid-cell-padding, 6px);
+				padding-inline: var(--mo-data-grid-cell-padding, 3px);
 				user-select: none;
 				line-height: var(--mo-data-grid-row-height);
 				white-space: nowrap;

--- a/packages/DataGrid/DataGridCell.ts
+++ b/packages/DataGrid/DataGridCell.ts
@@ -123,7 +123,7 @@ export class DataGridCell<TValue extends KeyPathValueOf<TData>, TData = any, TDe
 		return css`
 			:host {
 				position: relative;
-				padding-inline: var(--mo-data-grid-cell-padding, 3px);
+				padding-inline: var(--mo-data-grid-cell-padding, 6px);
 				user-select: none;
 				line-height: var(--mo-data-grid-row-height);
 				white-space: nowrap;

--- a/packages/DataGrid/DataGridHeader.ts
+++ b/packages/DataGrid/DataGridHeader.ts
@@ -54,7 +54,7 @@ export class DataGridHeader<TData> extends Component {
 			}
 
 			.headerContent {
-				padding: 0 var(--mo-data-grid-cell-padding, 3px);
+				padding: 0 var(--mo-data-grid-cell-padding, 6px);
 				display: inline-block;
 				overflow: hidden !important;
 				color: var(--mo-color-foreground);

--- a/packages/DataGrid/DataGridHeader.ts
+++ b/packages/DataGrid/DataGridHeader.ts
@@ -155,7 +155,7 @@ export class DataGridHeader<TData> extends Component {
 	private get moreTemplate() {
 		return this.dataGrid.hasToolbar || this.dataGrid.sidePanelHidden ? html.nothing : html`
 			<mo-flex alignItems='end' justifyContent='center'
-				${style({ cursor: 'pointer' })}
+				${style({ cursor: 'pointer', position: 'sticky', insetInlineEnd: '0px', background: 'var(--mo-data-grid-sticky-part-color)', zIndex: '3' })}
 			>
 				<mo-icon-button dense icon='settings' ${style({ color: 'var(--mo-color-accent)', fontSize: 'large' })}
 					@click=${() => this.dataGrid.navigateToSidePanelTab(this.dataGrid.sidePanelTab ? undefined : DataGridSidePanelTab.Settings)}

--- a/packages/DataGrid/DataGridHeader.ts
+++ b/packages/DataGrid/DataGridHeader.ts
@@ -134,7 +134,6 @@ export class DataGridHeader<TData> extends Component {
 					<mo-data-grid-header-separator
 						.dataGrid=${this.dataGrid as any}
 						.column=${this.dataGrid.visibleColumns[index]}
-						@columnUpdate=${() => this.dataGrid.requestUpdate()}
 					></mo-data-grid-header-separator>
 				`)}
 			</mo-grid>

--- a/packages/DataGrid/DataGridHeader.ts
+++ b/packages/DataGrid/DataGridHeader.ts
@@ -1,4 +1,4 @@
-import { component, Component, css, html, ifDefined, property, event, join, style } from '@a11d/lit'
+import { component, Component, css, html, ifDefined, property, event, style } from '@a11d/lit'
 import { KeyboardController } from '@3mo/keyboard-controller'
 import { type Checkbox } from '@3mo/checkbox'
 import { DataGridSelectionMode, DataGridSortingStrategy, type ColumnDefinition, type DataGrid, DataGridSidePanelTab } from './index.js'
@@ -41,7 +41,13 @@ export class DataGridHeader<TData> extends Component {
 			:host {
 				--mo-data-grid-header-separator-height: 15px;
 				--mo-data-grid-header-separator-width: 2px;
-				display: inherit;
+				display: grid;
+				grid-template-columns: subgrid;
+				grid-column: -1 / 1;
+				background: var(--mo-data-grid-sticky-part-color);
+				position: sticky;
+				top: 0;
+				z-index: 4;
 				font-size: small;
 			}
 
@@ -54,7 +60,7 @@ export class DataGridHeader<TData> extends Component {
 			}
 
 			.headerContent {
-				padding: 0 var(--mo-data-grid-cell-padding, 6px);
+				padding: 0 var(--mo-data-grid-cell-padding, 3px);
 				display: inline-block;
 				overflow: hidden !important;
 				color: var(--mo-color-foreground);
@@ -79,27 +85,12 @@ export class DataGridHeader<TData> extends Component {
 		`
 	}
 
-	private get skeletonColumns() {
-		return [
-			this.dataGrid.detailsColumnWidth,
-			this.dataGrid.selectionColumnWidth,
-			'1fr',
-			this.dataGrid.moreColumnWidth
-		].filter((c): c is string => c !== undefined).join(' ')
-	}
-
-	private get separatorAdjustedColumns() {
-		return this.dataGrid.dataColumnsWidths.join(' var(--mo-data-grid-columns-gap) ')
-	}
-
 	protected override get template() {
 		return html`
-			<mo-grid id='header' columns=${this.skeletonColumns} columnGap='var(--mo-data-grid-columns-gap)'>
-				${this.detailsExpanderTemplate}
-				${this.selectionTemplate}
-				${this.contentTemplate}
-				${this.moreTemplate}
-			</mo-grid>
+			${this.detailsExpanderTemplate}
+			${this.selectionTemplate}
+			${this.contentTemplate}
+			${this.moreTemplate}
 		`
 	}
 
@@ -129,32 +120,33 @@ export class DataGridHeader<TData> extends Component {
 
 	private get contentTemplate() {
 		return html`
-			<mo-grid columns=${this.separatorAdjustedColumns}>
-				${join(this.dataGrid.visibleColumns.map(column => this.getHeaderCellTemplate(column)), index => html`
-					<mo-data-grid-header-separator
-						.dataGrid=${this.dataGrid as any}
-						.column=${this.dataGrid.visibleColumns[index]}
-					></mo-data-grid-header-separator>
-				`)}
-			</mo-grid>
+			${this.dataGrid.visibleColumns.map(this.getHeaderCellTemplate)}
 		`
 	}
 
-	private getHeaderCellTemplate(column: ColumnDefinition<TData>) {
+	private readonly getHeaderCellTemplate = (column: ColumnDefinition<TData>, index: number) => {
 		const sortingDefinition = this.dataGrid.getSortingDefinition(column)
 		const sortIcon = !sortingDefinition ? undefined : sortingDefinition.strategy === DataGridSortingStrategy.Ascending ? 'arrow_upward' : 'arrow_downward'
 		const sortingRank = !sortingDefinition || this.dataGrid.getSorting().length <= 1 ? undefined : sortingDefinition.rank
 
 		return html`
-			<mo-flex direction=${column.alignment === 'end' ? 'horizontal-reversed' : 'horizontal'} alignItems='center'
-				${style({ overflow: 'hidden', position: 'relative', cursor: 'pointer', userSelect: 'none' })}
-				@click=${() => this.sort(column)}
-			>
-				<div class='headerContent' ${style({ width: '100%', textAlign: column.alignment })} title=${column.title || column.heading}>${column.heading}</div>
+			<mo-flex direction=${column.alignment === 'end' ? 'horizontal-reversed' : 'horizontal'} alignItems='center' ${style({ position: 'relative' })}>
+				<mo-flex direction=${column.alignment === 'end' ? 'horizontal-reversed' : 'horizontal'} alignItems='center'
+					${style({ overflow: 'hidden', cursor: 'pointer', userSelect: 'none', flex: '1' })}
+					@click=${() => this.sort(column)}
+				>
+					<div class='headerContent' ${style({ width: '100%', textAlign: column.alignment })} title=${column.title || column.heading}>${column.heading}</div>
 
-				${sortIcon === undefined ? html.nothing : html`
-					${!sortingRank ? html.nothing : html`<span class='sort-rank'>${sortingRank}</span>`}
-					<mo-icon ${style({ color: 'var(--mo-color-accent)' })} icon=${ifDefined(sortIcon)}></mo-icon>
+					${sortIcon === undefined ? html.nothing : html`
+						${!sortingRank ? html.nothing : html`<span class='sort-rank'>${sortingRank}</span>`}
+						<mo-icon ${style({ color: 'var(--mo-color-accent)' })} icon=${ifDefined(sortIcon)}></mo-icon>
+					`}
+				</mo-flex>
+				${index === this.dataGrid.visibleColumns.length - 1 ? html.nothing : html`
+					<mo-data-grid-header-separator
+						.dataGrid=${this.dataGrid as any}
+						.column=${this.dataGrid.visibleColumns[index]}
+					></mo-data-grid-header-separator>
 				`}
 			</mo-flex>
 		`
@@ -162,7 +154,9 @@ export class DataGridHeader<TData> extends Component {
 
 	private get moreTemplate() {
 		return this.dataGrid.hasToolbar || this.dataGrid.sidePanelHidden ? html.nothing : html`
-			<mo-flex alignItems='center' justifyContent='center' ${style({ marginInlineEnd: '8px', cursor: 'pointer', position: 'relative' })}>
+			<mo-flex alignItems='end' justifyContent='center'
+				${style({ cursor: 'pointer' })}
+			>
 				<mo-icon-button dense icon='settings' ${style({ color: 'var(--mo-color-accent)', fontSize: 'large' })}
 					@click=${() => this.dataGrid.navigateToSidePanelTab(this.dataGrid.sidePanelTab ? undefined : DataGridSidePanelTab.Settings)}
 				></mo-icon-button>

--- a/packages/DataGrid/DataGridHeaderSeparator.ts
+++ b/packages/DataGrid/DataGridHeaderSeparator.ts
@@ -1,12 +1,9 @@
-import { Component, component, property, html, css, state, event, eventListener, style } from '@a11d/lit'
+import { Component, component, property, html, css, state, eventListener, style } from '@a11d/lit'
 import { type ColumnDefinition, type DataGrid } from './index.js'
 
-/** @fires columnUpdate */
 @component('mo-data-grid-header-separator')
 export class DataGridHeaderSeparator extends Component {
 	static disableResizing = false
-
-	@event() readonly columnUpdate!: EventDispatcher
 
 	@property({ type: Object }) dataGrid!: DataGrid<unknown>
 	@property({ type: Object }) column!: ColumnDefinition<unknown>
@@ -83,7 +80,6 @@ export class DataGridHeaderSeparator extends Component {
 		this.initialWidth = undefined
 		this.column.width = `${this.targetWidth}px`
 		this.dataGrid.setColumns(this.dataGrid.columns)
-		this.columnUpdate.dispatch()
 	}
 
 	@eventListener({ target: window, type: 'mousemove' })

--- a/packages/DataGrid/package.json
+++ b/packages/DataGrid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/data-grid",
-	"version": "0.5.17",
+	"version": "0.6.0",
 	"description": "A data grid web component",
 	"repository": {
 		"type": "git",

--- a/packages/DataGrid/package.json
+++ b/packages/DataGrid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/data-grid",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "A data grid web component",
 	"repository": {
 		"type": "git",

--- a/packages/DataGrid/rows/DataGridDefaultRow.ts
+++ b/packages/DataGrid/rows/DataGridDefaultRow.ts
@@ -9,6 +9,9 @@ export class DataGridDefaultRow<TData, TDetailsElement extends Element | undefin
 			${super.styles}
 
 			:host {
+				display: grid;
+				grid-template-columns: subgrid;
+				grid-column: -1 / 1;
 				min-height: var(--mo-data-grid-row-height);
 			}
 

--- a/packages/DataGrid/rows/DataGridDefaultRow.ts
+++ b/packages/DataGrid/rows/DataGridDefaultRow.ts
@@ -8,10 +8,8 @@ export class DataGridDefaultRow<TData, TDetailsElement extends Element | undefin
 		return css`
 			${super.styles}
 
-			mo-grid {
-				height: var(--mo-data-grid-row-height);
-				grid-template-columns: var(--mo-data-grid-columns);
-				column-gap: var(--mo-data-grid-columns-gap);
+			:host {
+				min-height: var(--mo-data-grid-row-height);
 			}
 
 			mo-flex {
@@ -22,6 +20,15 @@ export class DataGridDefaultRow<TData, TDetailsElement extends Element | undefin
 
 			#selectionContainer {
 				height: var(--mo-data-grid-row-height);
+			}
+
+			#detailsContainer {
+				grid-column: -1 / 1;
+			}
+
+			:host([has-sub-data]) #detailsContainer {
+				display: grid;
+				grid-template-columns: subgrid;
 			}
 
 			#detailsContainer [instanceof*=mo-data-grid] {

--- a/packages/DataGrid/rows/DataGridRow.ts
+++ b/packages/DataGrid/rows/DataGridRow.ts
@@ -68,9 +68,7 @@ export abstract class DataGridRow<TData, TDetailsElement extends Element | undef
 	static override get styles() {
 		return css`
 			:host {
-				display: grid;
-				grid-template-columns: subgrid;
-				grid-column: -1 / 1;
+				display: block;
 				position: relative;
 				height: auto;
 				width: 100%;
@@ -97,7 +95,6 @@ export abstract class DataGridRow<TData, TDetailsElement extends Element | undef
 
 			#contentContainer {
 				grid-column: -1 / 1;
-				grid-template-columns: subgrid;
 				cursor: pointer;
 				transition: 250ms;
 			}
@@ -165,7 +162,7 @@ export abstract class DataGridRow<TData, TDetailsElement extends Element | undef
 
 	protected override get template() {
 		return html`
-			<mo-grid id='contentContainer'
+			<mo-grid id='contentContainer' columns='subgrid'
 				@click=${() => this.handleContentClick()}
 				@dblclick=${() => this.handleContentDoubleClick()}
 				@auxclick=${(e: PointerEvent) => e.button !== 1 ? void 0 : this.handleContentMiddleClick()}

--- a/packages/DataGrid/rows/DataGridRow.ts
+++ b/packages/DataGrid/rows/DataGridRow.ts
@@ -285,18 +285,18 @@ export abstract class DataGridRow<TData, TDetailsElement extends Element | undef
 		}
 	}
 
-	async openContextMenu(mouseEvent?: MouseEvent) {
+	async openContextMenu(event?: PointerEvent) {
 		if (!this.dataGrid.hasContextMenu) {
 			return
 		}
 
-		mouseEvent?.stopPropagation()
+		event?.stopPropagation()
 
 		if (this.dataGrid.selectedData.includes(this.data) === false) {
 			this.dataGrid.select(this.dataGrid.selectionMode !== DataGridSelectionMode.None ? [this.data] : [])
 		}
 
-		const contextMenu = ContextMenu.open(mouseEvent || [0, 0], this.contextMenuTemplate)
+		const contextMenu = ContextMenu.open(event || [0, 0], this.contextMenuTemplate)
 		this.contextMenuOpen = true
 		const handler = (open: boolean) => {
 			this.contextMenuOpen = open

--- a/packages/DataGrid/rows/DataGridRow.ts
+++ b/packages/DataGrid/rows/DataGridRow.ts
@@ -68,7 +68,9 @@ export abstract class DataGridRow<TData, TDetailsElement extends Element | undef
 	static override get styles() {
 		return css`
 			:host {
-				display: block;
+				display: grid;
+				grid-template-columns: subgrid;
+				grid-column: -1 / 1;
 				position: relative;
 				height: auto;
 				width: 100%;
@@ -94,6 +96,8 @@ export abstract class DataGridRow<TData, TDetailsElement extends Element | undef
 			}
 
 			#contentContainer {
+				grid-column: -1 / 1;
+				grid-template-columns: subgrid;
 				cursor: pointer;
 				transition: 250ms;
 			}
@@ -149,7 +153,7 @@ export abstract class DataGridRow<TData, TDetailsElement extends Element | undef
 				display: none;
 			}
 
-			#detailsContainer > :first-child {
+			:host(:not([has-sub-data])) #detailsContainer > :first-child {
 				padding: 8px 0;
 			}
 
@@ -220,11 +224,11 @@ export abstract class DataGridRow<TData, TDetailsElement extends Element | undef
 
 	protected get contextMenuIconButtonTemplate() {
 		return this.dataGrid.hasContextMenu === false ? html.nothing : html`
-			<mo-flex justifyContent='center' alignItems='center'
-				@click=${this.openContextMenu}
-				@dblclick=${(e: Event) => e.stopPropagation()}
-			>
-				<mo-icon-button id='contextMenuIconButton' icon='more_vert'></mo-icon-button>
+			<mo-flex justifyContent='center' ${style({ height: '100%', placeSelf: 'end', position: 'sticky', insetInlineEnd: '0px', zIndex: '3', background: 'var(--mo-data-grid-sticky-part-color)' })}>
+				<mo-icon-button id='contextMenuIconButton' icon='more_vert' dense
+					@click=${this.openContextMenu}
+					@dblclick=${(e: Event) => e.stopPropagation()}
+				></mo-icon-button>
 			</mo-flex>
 		`
 	}
@@ -239,12 +243,11 @@ export abstract class DataGridRow<TData, TDetailsElement extends Element | undef
 		}
 
 		const subData = this.dataGrid.getSubData(this.data)
+		this.toggleAttribute('has-sub-data', !!subData)
 
 		if (subData) {
 			return html`
-				<mo-flex style='width: 100%; padding: 0px'>
-					${subData.map(data => this.dataGrid.getRowTemplate(data, undefined, this.level + 1))}
-				</mo-flex>
+				${subData.map(data => this.dataGrid.getRowTemplate(data, undefined, this.level + 1))}
 			`
 		}
 

--- a/packages/FetchableDataGrid/FetchableDataGrid.stories.ts
+++ b/packages/FetchableDataGrid/FetchableDataGrid.stories.ts
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/web-components'
+import { html } from '@a11d/lit'
+import p from './package.json'
+import './FetchableDataGrid.js'
+
+export default {
+	title: 'Fetchable Data Grid',
+	component: 'mo-fetchable-data-grid',
+	package: p,
+} as Meta
+
+type Person = { id: number, name: string, age: number, city: string }
+
+const generatePeople = (count: number) => {
+	const cities = ['Berlin', 'Hamburg', 'München', 'Köln', 'Frankfurt']
+	const names = ['Max', 'Moritz', 'Mia', 'Maja', 'Mika']
+	return new Array(count).fill(0).map((_, i) => ({
+		id: i + 1,
+		name: names[Math.floor(Math.random() * names.length)],
+		age: Math.floor(Math.random() * 80),
+		city: cities[Math.floor(Math.random() * cities.length)]
+	})) as Array<Person>
+}
+
+const twentyPeople = generatePeople(20)
+
+const columnsTemplate = html`
+	<mo-data-grid-column-number hidden nonEditable heading='ID' dataSelector='id'></mo-data-grid-column-number>
+	<mo-data-grid-column-text heading='Name' width='200px' dataSelector='name'></mo-data-grid-column-text>
+	<mo-data-grid-column-number .nonEditable=${(person: Person) => person.age > 30} heading='Age' dataSelector='age'></mo-data-grid-column-number>
+	<mo-data-grid-column-text heading='City' dataSelector='city'></mo-data-grid-column-text>
+`
+
+const fetchData = (data: Array<Person>) => async () => {
+	await new Promise(resolve => setTimeout(resolve, 2000))
+	return data
+}
+
+export const FetchableDataGrid: StoryObj = {
+	render: () => html`
+		<mo-fetchable-data-grid .parameters=${{}} .fetch=${fetchData(twentyPeople)} style='height: 500px; flex: 1'>
+			${columnsTemplate}
+		</mo-fetchable-data-grid>
+	`
+}
+
+export const NoFilters: StoryObj = {
+	render: () => html`
+		<mo-fetchable-data-grid .fetch=${fetchData(twentyPeople)} style='height: 500px; flex: 1'>
+			${columnsTemplate}
+		</mo-fetchable-data-grid>
+	`
+}

--- a/packages/FetchableDataGrid/FetchableDataGrid.ts
+++ b/packages/FetchableDataGrid/FetchableDataGrid.ts
@@ -230,13 +230,13 @@ export class FetchableDataGrid<TData, TDataFetcherParameters extends FetchableDa
 
 	private get fetchingTemplate() {
 		return html`
-			<mo-circular-progress ${style({ width: '48px', height: '48px', margin: 'auto' })}></mo-circular-progress>
+			<mo-circular-progress class='span-through' ${style({ width: '48px', height: '48px', margin: 'auto' })}></mo-circular-progress>
 		`
 	}
 
 	protected get noSelectionTemplate() {
 		return html`
-			<slot name='error-no-selection'>
+			<slot name='error-no-selection' class='span-through'>
 				<mo-empty-state icon='touch_app'>${t('Make a filter selection')}</mo-empty-state>
 			</slot>
 		`

--- a/packages/FetchableDataGrid/package.json
+++ b/packages/FetchableDataGrid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/fetchable-data-grid",
-	"version": "0.0.7",
+	"version": "0.1.0",
 	"description": "A fetchable variant of @3mo/data-grid",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION

feat(DataGrid): Add the ability to double click on the header separator to change the column width to fit the content

feat(DataGrid): The "more" column sticks to the end of the grid.

fix(DataGrid): Fix column resizing not working properly sometimes
