### PR TITLE
fix(Navigation): Specify styling for small devices

### DIFF
--- a/packages/DesignLibrary/navigation/Navigation.ts
+++ b/packages/DesignLibrary/navigation/Navigation.ts
@@ -97,6 +97,16 @@ export class Navigation extends Component {
 				height: 40px;
 				font-size: 0.875rem;
 			}
+
+			@media (max-width: 576px) {
+				#navbar-navigations {
+					display: none;
+				}
+
+				#navbar {
+					justify-content: space-between;
+				}
+			}
 		`
 	}
 
@@ -134,6 +144,11 @@ export class Navigation extends Component {
 	private async checkNavigationOverflow() {
 		// As the items render using a "repeat" directive, they are not immediately available in the DOM sometimes.
 		await new Promise(resolve => setTimeout(resolve))
+
+		if (matchMedia('(max-width: 576px)').matches) {
+			this.mobileNavigation = true
+			return
+		}
 
 		const lastNavigationItem = this.navigationsContainer.style.flexDirection === 'row-reverse'
 			? this.navigationsContainer.firstElementChild


### PR DESCRIPTION
@a11delavar, I know that you do not like `matchMedia` but there is no other way to make it work (just remove this `matchMedia` and see what happens: it starts flashing).

This is a part of https://3mo-ebusiness.atlassian.net/browse/DEV-8249 (https://github.com/3mo-esolutions/ebusiness-core/commit/caf8b222f8ea217635f7d5c50692f97f274af8eb).

It is an **optional** commit (everything works without it).