### PR TITLE
fix(Card): Add margin-bottom for Card to uncrop the shadow

### DIFF
--- a/packages/Card/Card.ts
+++ b/packages/Card/Card.ts
@@ -127,12 +127,14 @@ export class Card extends Component {
 
 	protected override get template() {
 		return html`
-			<mo-flex ${style({ width: '100%', height: '100%' })}>
-				${this.mediaTemplate}
-				${this.headerTemplate}
-				${this.bodyTemplate}
-				${this.footerTemplate}
-			</mo-flex>
+			<div ${style({ width: '100%', height: '100%' })}>
+				<mo-flex ${style({ width: '100%', height: '100%', marginBottom: '-2px' })}>
+					${this.mediaTemplate}
+					${this.headerTemplate}
+					${this.bodyTemplate}
+					${this.footerTemplate}
+				</mo-flex ${style({ width: '100%', height: '100%' })}>
+			</div>
 		`
 	}
 


### PR DESCRIPTION
We should leave `margin-bottom: -2px` even for cards without a `box-shadow` so they will have the same space (`::before` or having padding won't resolve this issue for dialogs, you can test it in `DialogShopProduct`).

@jira https://3mo.atlassian.net/browse/DEV-8285