### PR TITLE
fix(Tooltip): Always render a tooltip before the next paint on mobile devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18939,7 +18939,7 @@
 		},
 		"packages/Tooltip": {
 			"name": "@3mo/tooltip",
-			"version": "0.7.2-preview.4",
+			"version": "0.7.2-preview.5",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/popover": "x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18939,7 +18939,7 @@
 		},
 		"packages/Tooltip": {
 			"name": "@3mo/tooltip",
-			"version": "0.7.2-preview.0",
+			"version": "0.7.2-preview.1",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/popover": "x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18939,7 +18939,7 @@
 		},
 		"packages/Tooltip": {
 			"name": "@3mo/tooltip",
-			"version": "0.7.2-preview.3",
+			"version": "0.7.2-preview.4",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/popover": "x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18939,7 +18939,7 @@
 		},
 		"packages/Tooltip": {
 			"name": "@3mo/tooltip",
-			"version": "0.7.2-preview.2",
+			"version": "0.7.2-preview.3",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/popover": "x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17696,6 +17696,18 @@
 				"@a11d/lit-testing": "x"
 			}
 		},
+		"packages/CollapsibleCard/node_modules/@3mo/tooltip": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@3mo/tooltip/-/tooltip-0.7.1.tgz",
+			"integrity": "sha512-qh1QOqpW6Jin4uZVeP0LGnn+eNSUImi18i297KoqceZdoXYJC68hEUft86rt89gG6un7Xu+7T+B6PP1/G7TV9A==",
+			"dependencies": {
+				"@3mo/popover": "x",
+				"@3mo/theme": "x",
+				"@a11d/lit": "x",
+				"@a11d/lit-application": "x",
+				"tslib": "x"
+			}
+		},
 		"packages/Color": {
 			"name": "@3mo/color",
 			"version": "0.1.5",
@@ -17791,6 +17803,18 @@
 				"@a11d/lit": "x",
 				"@a11d/lit-application": "x",
 				"requestidlecallback-polyfill": "x",
+				"tslib": "x"
+			}
+		},
+		"packages/DataGrid/node_modules/@3mo/tooltip": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@3mo/tooltip/-/tooltip-0.7.1.tgz",
+			"integrity": "sha512-qh1QOqpW6Jin4uZVeP0LGnn+eNSUImi18i297KoqceZdoXYJC68hEUft86rt89gG6un7Xu+7T+B6PP1/G7TV9A==",
+			"dependencies": {
+				"@3mo/popover": "x",
+				"@3mo/theme": "x",
+				"@a11d/lit": "x",
+				"@a11d/lit-application": "x",
 				"tslib": "x"
 			}
 		},
@@ -17947,6 +17971,18 @@
 				"tslib": "x"
 			}
 		},
+		"packages/DesignLibrary/node_modules/@3mo/tooltip": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@3mo/tooltip/-/tooltip-0.7.1.tgz",
+			"integrity": "sha512-qh1QOqpW6Jin4uZVeP0LGnn+eNSUImi18i297KoqceZdoXYJC68hEUft86rt89gG6un7Xu+7T+B6PP1/G7TV9A==",
+			"dependencies": {
+				"@3mo/popover": "x",
+				"@3mo/theme": "x",
+				"@a11d/lit": "x",
+				"@a11d/lit-application": "x",
+				"tslib": "x"
+			}
+		},
 		"packages/Dialog": {
 			"name": "@3mo/dialog",
 			"version": "0.3.5",
@@ -17963,6 +17999,18 @@
 				"@a11d/lit": "x",
 				"@a11d/lit-application": "x",
 				"@material/web": "1.x",
+				"tslib": "x"
+			}
+		},
+		"packages/Dialog/node_modules/@3mo/tooltip": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@3mo/tooltip/-/tooltip-0.7.1.tgz",
+			"integrity": "sha512-qh1QOqpW6Jin4uZVeP0LGnn+eNSUImi18i297KoqceZdoXYJC68hEUft86rt89gG6un7Xu+7T+B6PP1/G7TV9A==",
+			"dependencies": {
+				"@3mo/popover": "x",
+				"@3mo/theme": "x",
+				"@a11d/lit": "x",
+				"@a11d/lit-application": "x",
 				"tslib": "x"
 			}
 		},
@@ -18103,6 +18151,18 @@
 				"@3mo/icon-button": "x",
 				"@3mo/tooltip": "x",
 				"@a11d/lit": "x",
+				"tslib": "x"
+			}
+		},
+		"packages/FetchableDataGrid/node_modules/@3mo/tooltip": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@3mo/tooltip/-/tooltip-0.7.1.tgz",
+			"integrity": "sha512-qh1QOqpW6Jin4uZVeP0LGnn+eNSUImi18i297KoqceZdoXYJC68hEUft86rt89gG6un7Xu+7T+B6PP1/G7TV9A==",
+			"dependencies": {
+				"@3mo/popover": "x",
+				"@3mo/theme": "x",
+				"@a11d/lit": "x",
+				"@a11d/lit-application": "x",
 				"tslib": "x"
 			}
 		},
@@ -18488,6 +18548,18 @@
 				"tslib": "x"
 			}
 		},
+		"packages/ModdableDataGrid/node_modules/@3mo/tooltip": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@3mo/tooltip/-/tooltip-0.7.1.tgz",
+			"integrity": "sha512-qh1QOqpW6Jin4uZVeP0LGnn+eNSUImi18i297KoqceZdoXYJC68hEUft86rt89gG6un7Xu+7T+B6PP1/G7TV9A==",
+			"dependencies": {
+				"@3mo/popover": "x",
+				"@3mo/theme": "x",
+				"@a11d/lit": "x",
+				"@a11d/lit-application": "x",
+				"tslib": "x"
+			}
+		},
 		"packages/MutationObserver": {
 			"name": "@3mo/mutation-observer",
 			"version": "0.0.9",
@@ -18867,7 +18939,7 @@
 		},
 		"packages/Tooltip": {
 			"name": "@3mo/tooltip",
-			"version": "0.7.1",
+			"version": "0.7.2-preview.0",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/popover": "x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18939,7 +18939,7 @@
 		},
 		"packages/Tooltip": {
 			"name": "@3mo/tooltip",
-			"version": "0.7.2-preview.6",
+			"version": "0.7.2-preview.7",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/popover": "x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18939,7 +18939,7 @@
 		},
 		"packages/Tooltip": {
 			"name": "@3mo/tooltip",
-			"version": "0.7.2-preview.5",
+			"version": "0.7.2-preview.6",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/popover": "x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18939,7 +18939,7 @@
 		},
 		"packages/Tooltip": {
 			"name": "@3mo/tooltip",
-			"version": "0.7.2-preview.1",
+			"version": "0.7.2-preview.2",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/popover": "x",

--- a/packages/Tooltip/Tooltip.ts
+++ b/packages/Tooltip/Tooltip.ts
@@ -67,7 +67,7 @@ export class Tooltip extends Component {
 
 	private openIfApplicable = () => {
 		if (this.isMobile) {
-			return requestAnimationFrame(() => this.handleOpen())
+			return setTimeout(() => requestAnimationFrame(() => this.handleOpen()), 0)
 		}
 
 		return this.handleOpen()

--- a/packages/Tooltip/Tooltip.ts
+++ b/packages/Tooltip/Tooltip.ts
@@ -67,7 +67,7 @@ export class Tooltip extends Component {
 
 	private openIfApplicable = () => {
 		if (this.isMobile) {
-			return setTimeout(() => this.handleOpen(), 3)
+			return requestAnimationFrame(() => this.handleOpen())
 		}
 
 		return this.handleOpen()

--- a/packages/Tooltip/Tooltip.ts
+++ b/packages/Tooltip/Tooltip.ts
@@ -3,6 +3,7 @@ import { type TooltipPlacement } from './TooltipPlacement.js'
 import { type FocusMethod, FocusController } from '@3mo/focus-controller'
 import { PointerController } from '@3mo/pointer-controller'
 import { type ComputePositionReturn, arrow, type Middleware } from '@floating-ui/core'
+import * as System from 'detect-browser'
 
 function targetAnchor(this: Tooltip) {
 	return this.anchor || []
@@ -18,6 +19,8 @@ function targetAnchor(this: Tooltip) {
  */
 @component('mo-tooltip')
 export class Tooltip extends Component {
+	static mobileInteractionDelay = 1
+
 	private static readonly tipSideByPlacement = new Map([
 		['top', 'bottom'],
 		['right', 'left'],
@@ -45,9 +48,14 @@ export class Tooltip extends Component {
 		},
 	})
 
+	private get isMobile() {
+		const osName = System.detect()?.os
+		return osName && ['iOS', 'Android OS', 'BlackBerry OS', 'Windows Mobile', 'Amazon OS'].includes(osName)
+	}
+
 	private openIfApplicable = async () => {
-		if (window.matchMedia('(max-width: 576px)').matches) {
-			await new Promise(resolve => setTimeout(resolve, 1_000))
+		if (this.isMobile) {
+			await new Promise(resolve => setTimeout(resolve, Tooltip.mobileInteractionDelay))
 		}
 
 		if (this.pointerController.type === 'touch') {

--- a/packages/Tooltip/Tooltip.ts
+++ b/packages/Tooltip/Tooltip.ts
@@ -51,7 +51,7 @@ export class Tooltip extends Component {
 		return osName && ['iOS', 'Android OS', 'BlackBerry OS', 'Windows Mobile', 'Amazon OS'].includes(osName)
 	}
 
-	private _openIfApplicable = () => {
+	private handleOpen = () => {
 		if (this.pointerController.type === 'touch') {
 			this.setOpen(this.anchorPointerController.press)
 			return
@@ -67,10 +67,10 @@ export class Tooltip extends Component {
 
 	private openIfApplicable = () => {
 		if (this.isMobile) {
-			return requestIdleCallback(() => this._openIfApplicable())
+			return setTimeout(() => this.handleOpen(), 1)
 		}
 
-		return this._openIfApplicable()
+		return this.handleOpen()
 	}
 
 	private setOpen(open: boolean) {

--- a/packages/Tooltip/Tooltip.ts
+++ b/packages/Tooltip/Tooltip.ts
@@ -67,7 +67,7 @@ export class Tooltip extends Component {
 
 	private openIfApplicable = () => {
 		if (this.isMobile) {
-			return setTimeout(() => this.handleOpen(), 1_000)
+			return requestAnimationFrame(() => this.handleOpen())
 		}
 
 		return this.handleOpen()

--- a/packages/Tooltip/Tooltip.ts
+++ b/packages/Tooltip/Tooltip.ts
@@ -67,7 +67,7 @@ export class Tooltip extends Component {
 
 	private openIfApplicable = () => {
 		if (this.isMobile) {
-			return setTimeout(() => this.handleOpen(), 1)
+			return setTimeout(() => this.handleOpen(), 1_000)
 		}
 
 		return this.handleOpen()

--- a/packages/Tooltip/Tooltip.ts
+++ b/packages/Tooltip/Tooltip.ts
@@ -45,7 +45,11 @@ export class Tooltip extends Component {
 		},
 	})
 
-	private openIfApplicable = () => {
+	private openIfApplicable = async () => {
+		if (window.matchMedia('(max-width: 576px)').matches) {
+			await new Promise(resolve => setTimeout(resolve, 1_000))
+		}
+
 		if (this.pointerController.type === 'touch') {
 			this.setOpen(this.anchorPointerController.press)
 			return

--- a/packages/Tooltip/Tooltip.ts
+++ b/packages/Tooltip/Tooltip.ts
@@ -19,8 +19,6 @@ function targetAnchor(this: Tooltip) {
  */
 @component('mo-tooltip')
 export class Tooltip extends Component {
-	static mobileInteractionDelay = 1
-
 	private static readonly tipSideByPlacement = new Map([
 		['top', 'bottom'],
 		['right', 'left'],
@@ -53,11 +51,7 @@ export class Tooltip extends Component {
 		return osName && ['iOS', 'Android OS', 'BlackBerry OS', 'Windows Mobile', 'Amazon OS'].includes(osName)
 	}
 
-	private openIfApplicable = async () => {
-		if (this.isMobile) {
-			await new Promise(resolve => setTimeout(resolve, Tooltip.mobileInteractionDelay))
-		}
-
+	private _openIfApplicable = () => {
 		if (this.pointerController.type === 'touch') {
 			this.setOpen(this.anchorPointerController.press)
 			return
@@ -69,6 +63,14 @@ export class Tooltip extends Component {
 		}
 
 		this.setOpen(this.pointerController.hover || this.anchorPointerController.hover)
+	}
+
+	private openIfApplicable = () => {
+		if (this.isMobile) {
+			return requestIdleCallback(() => this._openIfApplicable())
+		}
+
+		return this._openIfApplicable()
 	}
 
 	private setOpen(open: boolean) {

--- a/packages/Tooltip/Tooltip.ts
+++ b/packages/Tooltip/Tooltip.ts
@@ -67,7 +67,7 @@ export class Tooltip extends Component {
 
 	private openIfApplicable = () => {
 		if (this.isMobile) {
-			return setTimeout(() => requestAnimationFrame(() => this.handleOpen()), 0)
+			return setTimeout(() => this.handleOpen(), 3)
 		}
 
 		return this.handleOpen()

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/tooltip",
-	"version": "0.7.2-preview.3",
+	"version": "0.7.2-preview.4",
 	"description": "A tooltip web-component with Lit directives.",
 	"repository": {
 		"type": "git",

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/tooltip",
-	"version": "0.7.2-preview.2",
+	"version": "0.7.2-preview.3",
 	"description": "A tooltip web-component with Lit directives.",
 	"repository": {
 		"type": "git",

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/tooltip",
-	"version": "0.7.2-preview.5",
+	"version": "0.7.2-preview.6",
 	"description": "A tooltip web-component with Lit directives.",
 	"repository": {
 		"type": "git",

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/tooltip",
-	"version": "0.7.2-preview.4",
+	"version": "0.7.2-preview.5",
 	"description": "A tooltip web-component with Lit directives.",
 	"repository": {
 		"type": "git",

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/tooltip",
-	"version": "0.7.2-preview.1",
+	"version": "0.7.2-preview.2",
 	"description": "A tooltip web-component with Lit directives.",
 	"repository": {
 		"type": "git",

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/tooltip",
-	"version": "0.7.2-preview.6",
+	"version": "0.7.2-preview.7",
 	"description": "A tooltip web-component with Lit directives.",
 	"repository": {
 		"type": "git",

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/tooltip",
-	"version": "0.7.1",
+	"version": "0.7.2-preview.0",
 	"description": "A tooltip web-component with Lit directives.",
 	"repository": {
 		"type": "git",

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/tooltip",
-	"version": "0.7.2-preview.0",
+	"version": "0.7.2-preview.1",
 	"description": "A tooltip web-component with Lit directives.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
My original intention was to add a slight delay before rendering a tooltip so the user won't see anything if he just touches an icon but it doesn't fix an original bug (sometimes it just renders a tooltip or even plays focus ring animation without calling an action). There is also no significant difference between `setTimeout(() => …, 0)`, `requestIdleCallback` or `requestAnimationFrame` but the last one seems to work slightly better.

We will rework the tooltip on mobile devices in the future but we do not have a concept for now.