### PR TITLE
fix(Toolbar): Overflow not being detected and opener not opening

### DIFF
--- a/packages/Toolbar/Toolbar.ts
+++ b/packages/Toolbar/Toolbar.ts
@@ -3,7 +3,6 @@ import { type MaterialIcon } from '@3mo/icon'
 import { ToolbarController } from './index.js'
 
 import '@3mo/popover'
-import '@3mo/flex'
 import '@3mo/menu'
 import '@3mo/icon-button'
 

--- a/packages/Toolbar/Toolbar.ts
+++ b/packages/Toolbar/Toolbar.ts
@@ -25,10 +25,6 @@ export class Toolbar extends Component {
 
 	static override get styles() {
 		return css`
-			mo-toolbar-pane {
-				flex: 1 1;
-			}
-
 			:host([collapsed]) mo-toolbar-pane {
 				display: none
 			}

--- a/packages/Toolbar/Toolbar.ts
+++ b/packages/Toolbar/Toolbar.ts
@@ -2,6 +2,11 @@ import { Component, component, css, html, property, style } from '@a11d/lit'
 import { type MaterialIcon } from '@3mo/icon'
 import { ToolbarController } from './index.js'
 
+import '@3mo/popover'
+import '@3mo/flex'
+import '@3mo/menu'
+import '@3mo/icon-button'
+
 /**
  * @element mo-toolbar
  *
@@ -13,7 +18,6 @@ import { ToolbarController } from './index.js'
  * @csspart overflowIcon - The overflow icon
  *
  * @slot - The default slot containing toolbar pane items
- * @slot overflow - The overflow action element(s)
  */
 @component('mo-toolbar')
 export class Toolbar extends Component {
@@ -40,7 +44,7 @@ export class Toolbar extends Component {
 					alignment=${(this.collapsed || this.overflowPosition === 'start') ? 'start' : 'end'}
 					${style({ flex: '0 0', justifyContent: 'flex-end', order: this.overflowPosition === 'start' ? -1 : 'unset' })}
 				>
-					<slot name='overflow'>${this.defaultOverflowOpenerTemplate}</slot>
+					${this.defaultOverflowOpenerTemplate}
 					${this.menuTemplate}
 				</mo-popover-container>
 			</mo-flex>

--- a/packages/Toolbar/ToolbarPane.ts
+++ b/packages/Toolbar/ToolbarPane.ts
@@ -18,11 +18,10 @@ export class ToolbarPane extends Component {
 	static override get styles() {
 		return css`
 			:host {
-				display: flex;
+				display: inline-block;
+				flex: 1 1 0;
+				width: 0;
 				overflow: clip;
-				flex-direction: row;
-				align-items: center;
-				align-content: center;
 			}
 
 			:host(:focus) {
@@ -30,7 +29,10 @@ export class ToolbarPane extends Component {
 			}
 
 			mo-flex {
-				flex-direction: inherit;
+				overflow: clip;
+				flex-direction: row;
+				align-items: center;
+				align-content: center;
 			}
 
 			::slotted(*) {
@@ -52,9 +54,11 @@ export class ToolbarPane extends Component {
 
 	protected override get template() {
 		return html`
-			<div id='pad'></div>
-			<slot @slotchange=${() => this.itemsChange.dispatch()}></slot>
-			<div id='filler' ${observeResize(elements => this.fillerResize.dispatch(elements))}></div>
+			<mo-flex part='pane'>
+				<div id='pad'></div>
+				<slot @slotchange=${() => this.itemsChange.dispatch()}></slot>
+				<div id='filler' ${observeResize(elements => this.fillerResize.dispatch(elements))}></div>
+			</mo-flex>
 		`
 	}
 }

--- a/packages/Toolbar/index.ts
+++ b/packages/Toolbar/index.ts
@@ -1,3 +1,5 @@
+import '@3mo/flex'
+
 export * from './ToolbarController.js'
 export * from './ToolbarPane.js'
 export * from './Toolbar.js'

--- a/packages/Toolbar/package.json
+++ b/packages/Toolbar/package.json
@@ -28,7 +28,8 @@
 		"tslib": "x",
 		"@3mo/theme": "x",
 		"@3mo/popover": "x",
-		"@3mo/list": "x",
+		"@3mo/icon-button": "x",
+		"@3mo/menu": "x",
 		"@3mo/disabled-property": "x",
 		"@3mo/slot-controller": "x"
 	}


### PR DESCRIPTION
- Disabled slotted overflow opener in the Toolbar element to fix an issue where `popover-container` failed to register the opener as anchor hence preventing it from opening.
- Modified the ToolbarPane flex-related calculations to make sure it remains isolated, ensuring overflow detection. 