### PR TITLE
feat(DataGrid): Row content selection now overrides previous selections, while checkbox selection preserves them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13462,7 +13462,7 @@
 		},
 		"packages/DataGrid": {
 			"name": "@3mo/data-grid",
-			"version": "0.17.2",
+			"version": "0.18.0",
 			"license": "MIT",
 			"dependencies": {
 				"@3mo/checkbox": "x",

--- a/packages/DataGrid/DataGrid.stories.ts
+++ b/packages/DataGrid/DataGrid.stories.ts
@@ -12,10 +12,9 @@ export default {
 		preventVerticalContentScroll: { control: 'boolean' },
 		selectability: {
 			control: 'select',
-			options: [DataGridSelectability.None, DataGridSelectability.Single, DataGridSelectability.Multiple]
+			options: [undefined, DataGridSelectability.Single, DataGridSelectability.Multiple]
 		},
 		selectOnClick: { control: 'boolean', type: 'boolean' },
-		selectionCheckboxesHidden: { control: 'boolean' },
 		selectionBehaviorOnDataChange: {
 			control: 'select',
 			options: [DataGridSelectionBehaviorOnDataChange.Reset, DataGridSelectionBehaviorOnDataChange.Maintain, DataGridSelectionBehaviorOnDataChange.Prevent]
@@ -108,7 +107,6 @@ export const Selection: StoryObj = {
 	args: {
 		selectability: 'single',
 		selectOnClick: false,
-		selectionCheckboxesHidden: false,
 	},
 	parameters: {
 		docs: {
@@ -117,10 +115,9 @@ export const Selection: StoryObj = {
 			},
 		}
 	},
-	render: ({ selectability, selectOnClick, selectionCheckboxesHidden }) => html`
+	render: ({ selectability, selectOnClick }) => html`
 		<mo-data-grid .data=${fivePeople} style='height: 500px' selectability=${selectability as any}
 			?selectOnClick=${selectOnClick}
-			?selectionCheckboxesHidden=${selectionCheckboxesHidden}
 			.isDataSelectable=${(person: Person) => person.age >= 18}
 		>
 			${columnsTemplate}

--- a/packages/DataGrid/DataGrid.test.ts
+++ b/packages/DataGrid/DataGrid.test.ts
@@ -131,6 +131,8 @@ describe('DataGrid', () => {
 		}
 
 		const expectCellFocusLeadsToRowSelectionWhenSelectOnClick = async (fixture: ComponentTestFixture<TestDataGrid>) => {
+			const shouldPreservePreviousSelection = fixture.component.selectability === DataGridSelectability.Multiple && fixture.component.selectOnClick
+
 			fixture.component.selectOnClick = true
 			await fixture.updateComplete
 
@@ -144,8 +146,7 @@ describe('DataGrid', () => {
 				.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', shiftKey: true }))
 			await fixture.updateComplete
 
-			const shouldHaveAddedSelection = fixture.component.selectability === DataGridSelectability.Multiple && fixture.component.selectOnClick
-			expect(fixture.component.isRowSelected(fixture.component.rows.at(1)!)).toBe(shouldHaveAddedSelection)
+			expect(fixture.component.isRowSelected(fixture.component.rows.at(1)!)).toBe(shouldPreservePreviousSelection)
 			expect(fixture.component.isRowSelected(fixture.component.rows.at(2)!)).toBe(true)
 		}
 

--- a/packages/DataGrid/DataGrid.test.ts
+++ b/packages/DataGrid/DataGrid.test.ts
@@ -131,7 +131,7 @@ describe('DataGrid', () => {
 		}
 
 		const expectCellFocusLeadsToRowSelectionWhenSelectOnClick = async (fixture: ComponentTestFixture<TestDataGrid>) => {
-			const shouldPreservePreviousSelection = fixture.component.selectability === DataGridSelectability.Multiple && fixture.component.selectOnClick
+			const shouldPreservePreviousSelection = fixture.component.selectability === DataGridSelectability.Multiple
 
 			fixture.component.selectOnClick = true
 			await fixture.updateComplete

--- a/packages/DataGrid/DataGrid.ts
+++ b/packages/DataGrid/DataGrid.ts
@@ -38,11 +38,10 @@ export enum DataGridEditability {
  * @attr page - The current page.
  * @attr pagination - The pagination mode. It can be either `auto` or a number.
  * @attr sorting - The sorting mode. It is an object with `selector` and `strategy` properties.
- * @attr selectability - The selection mode. Default to 'single' with @see DataGrid.selectionCheckboxesHidden set to true if context menus available, 'none' otherwise.
+ * @attr selectability - The selection mode. Default to 'single' if context menus available, 'undefined' otherwise.
  * @attr isDataSelectable - Whether data of a given row is selectable.
  * @attr selectedData - The selected data.
  * @attr selectOnClick - Whether the row should be selected on click.
- * @attr selectionCheckboxesHidden - Whether the selection checkboxes should be hidden. This activates selection on row click ignoring the `selectOnClick` attribute.
  * @attr selectionBehaviorOnDataChange - The behavior of the selection when the data changes.
  * @attr multipleDetails - Whether multiple details can be opened at the same time.
  * @attr subDataGridDataSelector - The key path of the sub data grid data.
@@ -126,7 +125,6 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 	@property({ type: Object }) isDataSelectable?: (data: TData) => boolean
 	@property({ type: Array, event: 'selectionChange' }) selectedData = new Array<TData>()
 	@property({ type: Boolean }) selectOnClick = false
-	@property({ type: Boolean }) selectionCheckboxesHidden = false
 	@property() selectionBehaviorOnDataChange = DataGridSelectionBehaviorOnDataChange.Reset
 
 	@property({ type: Object }) getRowDetailsTemplate?: (data: TData) => HTMLTemplateResult
@@ -422,7 +420,6 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 				--mo-data-grid-toolbar-padding: 0px 14px 14px 14px;
 				--mo-data-grid-border: 1px solid var(--mo-color-transparent-gray-3);
 
-				--mo-data-grid-row-tree-line-width: 8px;
 				--mo-details-data-grid-start-margin: 26px;
 
 				--mo-data-grid-sticky-part-color: var(--mo-color-surface);
@@ -456,14 +453,6 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 				&::part(container) {
 					position: relative;
 				}
-			}
-
-			:host(:not([selectability="none"])) {
-				--mo-data-grid-row-tree-line-width: 18px;
-			}
-
-			:host([hasDetails]) {
-				--mo-data-grid-row-tree-line-width: 18px;
 			}
 
 			#content {
@@ -711,7 +700,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 			</style>
 			<div id='size-anchor'>
 				${!this.hasDetails ? html.nothing : html`<span></span>`}
-				${!this.hasSelection || this.selectionCheckboxesHidden ? html.nothing : html`<span></span>`}
+				${!this.hasSelection ? html.nothing : html`<span></span>`}
 				${this.visibleColumns.map(column => html`
 					<div style='--_max-level: ${Math.max(...this.dataRecords.map(dr => dr.level))}'>
 						${getLongestContent(column)}
@@ -733,7 +722,7 @@ export class DataGrid<TData, TDetailsElement extends Element | undefined = undef
 	protected get footerTemplate() {
 		return html`
 			<mo-flex ${style({ position: 'relative' })}>
-				<mo-flex id='fab' direction='vertical-reversed' gap='8px'>
+				<mo-flex id='fab' direction='vertical-reversed' gap='0.5rem'>
 					${this.fabTemplate}
 				</mo-flex>
 				${this.hasFooter === false ? html.nothing : html`

--- a/packages/DataGrid/DataGridCell.ts
+++ b/packages/DataGrid/DataGridCell.ts
@@ -114,8 +114,8 @@ export class DataGridCell<TValue extends KeyPath.ValueOf<TData>, TData = any, TD
 			event.preventDefault()
 			cell.focus()
 			this.setEditing(false)
-			if (this.dataGrid.selectionCheckboxesHidden) {
-				this.dataGrid.select([...(event.shiftKey ? this.dataGrid.selectedData : []), cell.row.data])
+			if (this.dataGrid.selectOnClick) {
+				this.dataGrid.selectionController.setSelection(cell.row.data, true, event.shiftKey)
 			}
 		}
 	}

--- a/packages/DataGrid/DataGridColumnsController.ts
+++ b/packages/DataGrid/DataGridColumnsController.ts
@@ -70,7 +70,7 @@ export class DataGridColumnsController<TData> extends Controller {
 	}
 
 	private get selectionColumnWidth() {
-		return !this.host.hasSelection || this.host.selectionCheckboxesHidden ? undefined : window.getComputedStyle(this.host).getPropertyValue('--mo-data-grid-column-selection-width')
+		return !this.host.hasSelection ? undefined : window.getComputedStyle(this.host).getPropertyValue('--mo-data-grid-column-selection-width')
 	}
 
 	private get dataColumnsWidths() {

--- a/packages/DataGrid/DataGridHeader.ts
+++ b/packages/DataGrid/DataGridHeader.ts
@@ -126,7 +126,7 @@ export class DataGridHeader<TData> extends Component {
 	}
 
 	private get selectionTemplate() {
-		return this.dataGrid.hasSelection === false || this.dataGrid.selectionCheckboxesHidden ? html.nothing : html`
+		return !this.dataGrid.hasSelection ? html.nothing : html`
 			<mo-flex class='selection' justifyContent='center' alignItems='center'
 				${style({ insetInlineStart: this.dataGrid.hasDetails ? '20px' : '0px' })}
 				${this.getResizeObserver('selectionColumnWidthInPixels')}

--- a/packages/DataGrid/DataGridSelectionController.test.ts
+++ b/packages/DataGrid/DataGridSelectionController.test.ts
@@ -22,7 +22,7 @@ describe('DataGridSelectionController', () => {
 	})
 
 	describe('hasSelection', () => {
-		for (const [mode, hasSelection] of [[DataGridSelectability.None, false], [DataGridSelectability.Single, true], [DataGridSelectability.Multiple, true]] as const) {
+		for (const [mode, hasSelection] of [[undefined, false], [DataGridSelectability.Single, true], [DataGridSelectability.Multiple, true]] as const) {
 			it(`should return ${hasSelection} when mode is ${mode}`, () => {
 				controller.host.selectability = mode
 				expect(controller.hasSelection).toBe(hasSelection)
@@ -31,11 +31,10 @@ describe('DataGridSelectionController', () => {
 	})
 
 	describe('selectability', () => {
-		it('should default to "none" normally', () => {
+		it('should default to "undefined" normally', () => {
 			controller.hasSelection
-			expect(controller.host.selectability).toBe(DataGridSelectability.None)
+			expect(controller.host.selectability).toBe(undefined)
 		})
-
 		it('should default to "single" when has context menu', () => {
 			controller = new DataGridSelectionController<Data>({
 				hasContextMenu: true,
@@ -47,7 +46,7 @@ describe('DataGridSelectionController', () => {
 		})
 
 		it('should not change when already defined', () => {
-			for (const selectability of [DataGridSelectability.None, DataGridSelectability.Multiple]) {
+			for (const selectability of [undefined, DataGridSelectability.Multiple]) {
 				controller = new DataGridSelectionController<Data>({
 					selectability,
 					hasContextMenu: true,
@@ -88,7 +87,7 @@ describe('DataGridSelectionController', () => {
 	})
 
 	describe('selectAll', () => {
-		for (const [mode, selectedData] of [[DataGridSelectability.None, []], [DataGridSelectability.Single, []], [DataGridSelectability.Multiple, [...data]]] as const) {
+		for (const [mode, selectedData] of [[undefined, []], [DataGridSelectability.Single, []], [DataGridSelectability.Multiple, [...data]]] as const) {
 			it(`should ${!data.length ? 'not' : ''} select data when mode is ${mode}`, () => {
 				controller.host.selectability = mode
 				Object.defineProperty(controller.host, 'flattenedData', { value: [...data] })

--- a/packages/DataGrid/package.json
+++ b/packages/DataGrid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3mo/data-grid",
-	"version": "0.17.2",
+	"version": "0.18.0",
 	"description": "A data grid web component",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION

chore(DataGrid)!: Remove `selectionCheckboxesHidden` property

chore(DataGrid)!: Remove `DataGridSelectability.None` in favor of `undefined`